### PR TITLE
Add sonar ci analysis

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -63,6 +63,13 @@ jobs:
             ~/.gradle/wrapper
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
       # Load google-services.json and local.properties from the secrets
       - name: Decode secrets
         env:
@@ -172,6 +179,11 @@ jobs:
         with:
           name: Coverage report
           path: app/build/reports/jacoco/jacocoTestReport
+
+      - name: Sonar analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar --info
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.ktfmt)
     alias(libs.plugins.gms)
-
+    id("org.sonarqube") version "5.1.0.4882"
 }
 
 android {
@@ -118,6 +118,13 @@ android {
 
 }
 
+sonar {
+  properties {
+    property("sonar.projectKey", "EPFL-Life_life")
+    property("sonar.organization", "epfl-life")
+    property("sonar.host.url", "https://sonarcloud.io")
+  }
+}
 
 dependencies {
 


### PR DESCRIPTION
### Overview

We are currently using Sonar's [automatic analyis](https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/automatic-analysis), which does not support test coverage.

Therefore this PR switches to CI-based analysis. I already disabled automatic analysis in the sonar UI, since the two are incompatible.

### Implementation

- Add sonar gradle plugin and specify our project details
- Call the gradle sonar task at the end of the CI workflow. This uploads the coverage report to sonar as well.
- Add recommended caching for faster CI runs

### Note

There is a newer version of the sonar plugin available, but it doesn't actually work with our codebase (see this [issue](https://community.sonarsource.com/t/execution-failed-for-task-sonar/136857)). So we are using version 5 for now, which is already way newer than a bunch of their examples ; )

Resolves: #36 