### PR TITLE
Add clickability test for event card

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/ui/events/EventCardTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/events/EventCardTest.kt
@@ -1,0 +1,35 @@
+package ch.epfllife.ui.events
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import ch.epfllife.model.entities.Event
+import ch.epfllife.model.map.Location
+import ch.epfllife.ui.composables.EventCard
+import ch.epfllife.ui.composables.EventCardTestTags
+import ch.epfllife.utils.assertClickable
+import com.google.firebase.Timestamp
+import org.junit.Rule
+import org.junit.Test
+
+class EventCardTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+  private val event =
+      Event(
+          id = "0",
+          title = "Test Event",
+          description = "This is a test event",
+          location = Location(46.520278, 6.565556, "EPFL"),
+          time = Timestamp.now().toString(),
+          associationId = "assoc1",
+          tags = emptySet(),
+          price = 0u,
+      )
+
+  @Test
+  fun isClickable() {
+    composeTestRule.assertClickable(
+        { clickHandler -> EventCard(event, onClick = clickHandler) },
+        EventCardTestTags.EVENT_CARD,
+    )
+  }
+}

--- a/app/src/androidTest/java/ch/epfllife/utils/LifeTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/utils/LifeTest.kt
@@ -1,6 +1,7 @@
 package ch.epfllife.utils
 
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
@@ -10,6 +11,7 @@ import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -36,6 +38,7 @@ import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import org.junit.After
+import org.junit.Assert
 import org.junit.Before
 
 const val UI_WAIT_TIMEOUT = 5_000L
@@ -69,7 +72,8 @@ abstract class LifeTest() {
           dueDate = Timestamp.Companion.fromDate(2025, Calendar.SEPTEMBER, 1),
           location = Location(46.5191, 6.5668, "Lausanne Coop"),
           status = ToDoStatus.CREATED,
-          ownerId = "user")
+          ownerId = "user",
+      )
 
   open val todo2 =
       ToDo(
@@ -80,7 +84,8 @@ abstract class LifeTest() {
           dueDate = Timestamp.Companion.fromDate(2025, Calendar.OCTOBER, 15),
           location = Location(46.5210, 6.5790, "Parc de Mon Repos"),
           status = ToDoStatus.STARTED,
-          ownerId = "user")
+          ownerId = "user",
+      )
 
   open val todo3 =
       ToDo(
@@ -91,7 +96,8 @@ abstract class LifeTest() {
           dueDate = Timestamp.Companion.fromDate(2025, Calendar.NOVEMBER, 10),
           location = Location(46.5200, 6.5800, "City Library"),
           status = ToDoStatus.ARCHIVED,
-          ownerId = "user")
+          ownerId = "user",
+      )
 
   @Before
   open fun setUp() {
@@ -151,7 +157,8 @@ abstract class LifeTest() {
     onNode(
             hasTestTag(OverviewScreenTestTags.getTestTagForTodoItem(todo))
                 .and(hasAnyDescendant(matcher)),
-            useUnmergedTree = true)
+            useUnmergedTree = true,
+        )
         .assertIsDisplayed()
   }
 
@@ -165,7 +172,9 @@ abstract class LifeTest() {
     val hasTextLocation = hasText(location.name)
     val containsTextLocation = hasTextLocation.or(hasAnyDescendant(hasTextLocation))
     return onNode(
-        hasTestTag("locationSuggestion").and(containsTextLocation), useUnmergedTree = true)
+        hasTestTag("locationSuggestion").and(containsTextLocation),
+        useUnmergedTree = true,
+    )
   }
 
   fun ComposeTestRule.assertAllLocationSuggestionsAreDisplayed(fakeLocation: FakeLocation) {
@@ -210,4 +219,21 @@ abstract class LifeTest() {
       return Timestamp(calendar.time)
     }
   }
+}
+
+/**
+ * Assert that the composable triggers the given callback when the node with the given tag is
+ * clicked.
+ *
+ * This ensures that the composable is wired correctly and the UI can respond to user interactions.
+ */
+fun ComposeContentTestRule.assertClickable(
+    composable: @Composable ((callback: () -> Unit) -> Unit),
+    tag: String,
+) {
+  var clicked = false
+  this.setContent { composable { clicked = true } }
+  this.onNodeWithTag(tag).performClick()
+
+  Assert.assertTrue("$tag should be clickable", clicked)
 }

--- a/app/src/main/java/ch/epfllife/model/entities/Event.kt
+++ b/app/src/main/java/ch/epfllife/model/entities/Event.kt
@@ -2,8 +2,6 @@ package ch.epfllife.model.entities
 
 import ch.epfllife.model.map.Location
 
-// import com.google.firebase.Timestamp
-
 data class Event(
     val id: String,
     val title: String,

--- a/app/src/main/java/ch/epfllife/ui/composables/EventCard.kt
+++ b/app/src/main/java/ch/epfllife/ui/composables/EventCard.kt
@@ -15,9 +15,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import ch.epfllife.model.entities.Event
+
+object EventCardTestTags {
+  const val EVENT_CARD = "eventCard"
+}
 
 @Composable
 fun EventCard(event: Event, modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
@@ -26,7 +31,7 @@ fun EventCard(event: Event, modifier: Modifier = Modifier, onClick: () -> Unit =
       onClick = onClick,
       shape = RoundedCornerShape(12.dp),
       elevation = CardDefaults.elevatedCardElevation(5.dp),
-      modifier = modifier.fillMaxWidth()) {
+      modifier = modifier.fillMaxWidth().testTag(EventCardTestTags.EVENT_CARD)) {
         Column(Modifier.padding(horizontal = 16.dp, vertical = 14.dp)) {
           Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
             Text(
@@ -35,7 +40,12 @@ fun EventCard(event: Event, modifier: Modifier = Modifier, onClick: () -> Unit =
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.weight(1f))
             Text(
-                text = event.price?.let { "CHF $it" } ?: "Free",
+                text =
+                    if (event.price == 0u) {
+                      "Free"
+                    } else {
+                      "CHF ${event.price}"
+                    },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant)
             Spacer(Modifier.width(6.dp))


### PR DESCRIPTION
### Overview

Add `assertClickable` function to test utils. This function can be reused in other tests for checking clickability and proper callback invocation.

Add test that asserts that even cards are clickable.

Fix event price handling according to the type change.

### Note

There are a bunch of formatting changes that ktfmt applied as well.