### PR TITLE
Fix event details package

### DIFF
--- a/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
@@ -1,4 +1,4 @@
-package com.android.sample.ui.eventDetails
+package ch.epfllife.ui.eventDetails
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable

--- a/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsViewModel.kt
+++ b/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsViewModel.kt
@@ -1,4 +1,4 @@
-package com.android.sample.ui.eventDetails
+package ch.epfllife.ui.eventDetails
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope


### PR DESCRIPTION
In the transition from android sample to bootcamp s3, this package name was not updated.
Changing it to `ch.epfllife` package now.