### PR TITLE
Add UI tests for Model Enums ( EventFilter and Category ) 

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/model/enums/CategoryTests.kt
+++ b/app/src/androidTest/java/ch/epfllife/model/enums/CategoryTests.kt
@@ -3,145 +3,133 @@ package ch.epfllife.model.enums
 import org.junit.Assert.*
 import org.junit.Test
 
-
 class CategoryTests {
 
-    // --- Core behaviour --------------------------------------------------------
+  // --- Core behaviour --------------------------------------------------------
 
-    @Test
-    fun displayString_capitalizes_only_first_letter() {
-        assertEquals("Culture", Category.CULTURE.displayString())
-        assertEquals("Sports", Category.SPORTS.displayString())
-        assertEquals("Tech", Category.TECH.displayString())
-        assertEquals("Social", Category.SOCIAL.displayString())
-        assertEquals("Academic", Category.ACADEMIC.displayString())
-        assertEquals("Career", Category.CAREER.displayString())
-        assertEquals("Other", Category.OTHER.displayString())
+  @Test
+  fun displayString_capitalizes_only_first_letter() {
+    assertEquals("Culture", Category.CULTURE.displayString())
+    assertEquals("Sports", Category.SPORTS.displayString())
+    assertEquals("Tech", Category.TECH.displayString())
+    assertEquals("Social", Category.SOCIAL.displayString())
+    assertEquals("Academic", Category.ACADEMIC.displayString())
+    assertEquals("Career", Category.CAREER.displayString())
+    assertEquals("Other", Category.OTHER.displayString())
+  }
+
+  @Test
+  fun displayString_does_not_overcapitalize_when_already_proper() {
+    assertEquals("Tech", Category.TECH.displayString())
+  }
+
+  @Test
+  fun displayString_outputs_are_unique_and_non_empty() {
+    val outputs = Category.entries.map { it.displayString() }
+    assertEquals(outputs.size, outputs.distinct().size)
+    outputs.forEach { assertTrue(it.isNotEmpty()) }
+  }
+
+  @Test
+  fun displayString_is_Titlecase_formatted() {
+    Category.entries.forEach {
+      val display = it.displayString()
+      assertTrue(display.first().isUpperCase())
+      assertTrue(display.drop(1).all { ch -> ch.isLowerCase() })
     }
+  }
 
-    @Test
-    fun displayString_does_not_overcapitalize_when_already_proper() {
-        assertEquals("Tech", Category.TECH.displayString())
+  // --- Enum structure --------------------------------------------------------
+
+  @Test
+  fun enum_contains_all_expected_constants_in_correct_order() {
+    val names = Category.entries.map { it.name }
+    val expected = listOf("CULTURE", "SPORTS", "TECH", "SOCIAL", "ACADEMIC", "CAREER", "OTHER")
+    assertEquals(expected, names)
+  }
+
+  @Test
+  fun ordinals_are_in_increasing_sequence() {
+    val ordinals = Category.entries.map { it.ordinal }
+    assertEquals(ordinals, ordinals.sorted())
+  }
+
+  @Test
+  fun toString_returns_enum_name() {
+    Category.entries.forEach { c -> assertEquals(c.name, c.toString()) }
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun valueOf_throws_for_invalid_name() {
+    Category.valueOf("NOT_A_REAL_CATEGORY")
+  }
+
+  // --- Reversibility & round-trip -------------------------------------------
+
+  @Test
+  fun displayString_is_reversible_to_enum() {
+    Category.entries.forEach { cat ->
+      val reconstructed = Category.valueOf(cat.displayString().uppercase())
+      assertEquals(cat, reconstructed)
     }
+  }
 
-    @Test
-    fun displayString_outputs_are_unique_and_non_empty() {
-        val outputs = Category.entries.map { it.displayString() }
-        assertEquals(outputs.size, outputs.distinct().size)
-        outputs.forEach { assertTrue(it.isNotEmpty()) }
-    }
+  @Test
+  fun lowercase_and_mixedcase_names_resolve_correctly_via_custom_lookup() {
+    fun findByName(name: String): Category? =
+        Category.entries.firstOrNull { it.name.equals(name, ignoreCase = true) }
 
-    @Test
-    fun displayString_is_Titlecase_formatted() {
-        Category.entries.forEach {
-            val display = it.displayString()
-            assertTrue(display.first().isUpperCase())
-            assertTrue(display.drop(1).all { ch -> ch.isLowerCase() })
-        }
-    }
+    assertEquals(Category.CULTURE, findByName("culture"))
+    assertEquals(Category.SPORTS, findByName("Sports"))
+    assertNull(findByName("invalid"))
+  }
 
-    // --- Enum structure --------------------------------------------------------
+  @Test
+  fun enum_can_be_iterated_and_mapped_without_errors() {
+    val mapping = Category.entries.associateWith { it.displayString() }
+    assertEquals(Category.entries.size, mapping.size)
+  }
 
-    @Test
-    fun enum_contains_all_expected_constants_in_correct_order() {
-        val names = Category.entries.map { it.name }
-        val expected = listOf("CULTURE","SPORTS","TECH","SOCIAL","ACADEMIC","CAREER","OTHER")
-        assertEquals(expected, names)
-    }
+  // --- Defensive guards for future changes ----------------------------------
 
-    @Test
-    fun ordinals_are_in_increasing_sequence() {
-        val ordinals = Category.entries.map { it.ordinal }
-        assertEquals(ordinals, ordinals.sorted())
-    }
-
-    @Test
-    fun toString_returns_enum_name() {
-        Category.entries.forEach { c ->
-            assertEquals(c.name, c.toString())
-        }
-    }
-
-    @Test(expected = IllegalArgumentException::class)
-    fun valueOf_throws_for_invalid_name() {
-        Category.valueOf("NOT_A_REAL_CATEGORY")
-    }
-
-    // --- Reversibility & round-trip -------------------------------------------
-
-    @Test
-    fun displayString_is_reversible_to_enum() {
-        Category.entries.forEach { cat ->
-            val reconstructed = Category.valueOf(cat.displayString().uppercase())
-            assertEquals(cat, reconstructed)
-        }
-    }
-
-    @Test
-    fun lowercase_and_mixedcase_names_resolve_correctly_via_custom_lookup() {
-        fun findByName(name: String): Category? =
-            Category.entries.firstOrNull { it.name.equals(name, ignoreCase = true) }
-
-        assertEquals(Category.CULTURE, findByName("culture"))
-        assertEquals(Category.SPORTS, findByName("Sports"))
-        assertNull(findByName("invalid"))
-    }
-
- 
-
-    @Test
-    fun enum_can_be_iterated_and_mapped_without_errors() {
-        val mapping = Category.entries.associateWith { it.displayString() }
-        assertEquals(Category.entries.size, mapping.size)
-    }
-
-    // --- Defensive guards for future changes ----------------------------------
-
-    @Test
-    fun adding_new_constants_should_break_this_guard() {
-        val expected = setOf(
+  @Test
+  fun adding_new_constants_should_break_this_guard() {
+    val expected =
+        setOf(
             Category.CULTURE,
             Category.SPORTS,
             Category.TECH,
             Category.SOCIAL,
             Category.ACADEMIC,
             Category.CAREER,
-            Category.OTHER
-        )
-        val actual = Category.entries.toSet()
-        assertEquals(
-            "If this fails, update tests and UI for new Category entries.",
-            expected,
-            actual
-        )
-    }
+            Category.OTHER)
+    val actual = Category.entries.toSet()
+    assertEquals("If this fails, update tests and UI for new Category entries.", expected, actual)
+  }
 
-    // --- Edge / synthetic scenarios -------------------------------------------
+  // --- Edge / synthetic scenarios -------------------------------------------
 
-    @Test
-    fun lowercase_conversion_and_replaceFirstChar_behaviour_consistent() {
-        val raw = "EXAMPLE"
-        val result = raw.lowercase().replaceFirstChar { it.titlecase() }
-        assertEquals("Example", result)
-    }
+  @Test
+  fun lowercase_conversion_and_replaceFirstChar_behaviour_consistent() {
+    val raw = "EXAMPLE"
+    val result = raw.lowercase().replaceFirstChar { it.titlecase() }
+    assertEquals("Example", result)
+  }
 
-    @Test
-    fun all_displayStrings_have_first_character_alpha() {
-        Category.entries.forEach {
-            val display = it.displayString()
-            assertTrue(display.first().isLetter())
-        }
+  @Test
+  fun all_displayStrings_have_first_character_alpha() {
+    Category.entries.forEach {
+      val display = it.displayString()
+      assertTrue(display.first().isLetter())
     }
+  }
 
-    @Test
-    fun none_of_the_displayStrings_contain_underscores_or_numbers() {
-        Category.entries.forEach {
-            val s = it.displayString()
-            assertFalse(s.contains("_"))
-            assertTrue(s.all { ch -> !ch.isDigit() })
-        }
+  @Test
+  fun none_of_the_displayStrings_contain_underscores_or_numbers() {
+    Category.entries.forEach {
+      val s = it.displayString()
+      assertFalse(s.contains("_"))
+      assertTrue(s.all { ch -> !ch.isDigit() })
     }
+  }
 }
-
-
-

--- a/app/src/androidTest/java/ch/epfllife/model/enums/EventsFilterTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/model/enums/EventsFilterTest.kt
@@ -5,112 +5,101 @@ import org.junit.Test
 
 class EventsFilterTest {
 
+  @Test
+  fun enum_contains_Subscribed_and_All() {
+    val expected = setOf("Subscribed", "All")
+    val actual = EventsFilter.entries.map { it.name }.toSet()
+    assertEquals(expected, actual)
+  }
 
-    @Test
-    fun enum_contains_Subscribed_and_All() {
-        val expected = setOf("Subscribed", "All")
-        val actual = EventsFilter.entries.map { it.name }.toSet()
-        assertEquals(expected, actual)
-    }
+  @Test
+  fun names_match_expected() {
+    assertEquals("Subscribed", EventsFilter.Subscribed.name)
+    assertEquals("All", EventsFilter.All.name)
+  }
 
-    @Test
-    fun names_match_expected() {
-        assertEquals("Subscribed", EventsFilter.Subscribed.name)
-        assertEquals("All", EventsFilter.All.name)
-    }
+  @Test
+  fun entries_size_is_two_and_order_is_stable() {
+    val entries = EventsFilter.entries
+    assertEquals(2, entries.size)
+    // Order matters for ordinals and any persisted values
+    assertEquals(EventsFilter.Subscribed, entries[0])
+    assertEquals(EventsFilter.All, entries[1])
+  }
 
-    @Test
-    fun entries_size_is_two_and_order_is_stable() {
-        val entries = EventsFilter.entries
-        assertEquals(2, entries.size)
-        // Order matters for ordinals and any persisted values
-        assertEquals(EventsFilter.Subscribed, entries[0])
-        assertEquals(EventsFilter.All, entries[1])
-    }
+  @Test
+  fun ordinals_are_stable() {
+    assertEquals(0, EventsFilter.Subscribed.ordinal)
+    assertEquals(1, EventsFilter.All.ordinal)
+  }
 
+  @Test
+  fun toString_defaults_to_name() {
+    assertEquals("Subscribed", EventsFilter.Subscribed.toString())
+    assertEquals("All", EventsFilter.All.toString())
+  }
 
-    @Test
-    fun ordinals_are_stable() {
-        assertEquals(0, EventsFilter.Subscribed.ordinal)
-        assertEquals(1, EventsFilter.All.ordinal)
-    }
+  @Test
+  fun valueOf_roundtrip_matches_name() {
+    EventsFilter.entries.forEach { f -> assertEquals(f, EventsFilter.valueOf(f.name)) }
+  }
 
-    @Test
-    fun toString_defaults_to_name() {
-        assertEquals("Subscribed", EventsFilter.Subscribed.toString())
-        assertEquals("All", EventsFilter.All.toString())
-    }
+  @Test
+  fun valueOf_accepts_uppercase_name() {
+    assertEquals(EventsFilter.Subscribed, EventsFilter.valueOf("Subscribed"))
+    assertEquals(EventsFilter.All, EventsFilter.valueOf("All"))
+  }
 
+  @Test(expected = IllegalArgumentException::class)
+  fun valueOf_throws_for_invalid() {
+    EventsFilter.valueOf("NotAFilter")
+  }
 
-    @Test
-    fun valueOf_roundtrip_matches_name() {
-        EventsFilter.entries.forEach { f ->
-            assertEquals(f, EventsFilter.valueOf(f.name))
-        }
-    }
+  @Test
+  fun names_are_unique() {
+    val names = EventsFilter.entries.map { it.name }
+    assertEquals(names.size, names.distinct().size)
+  }
 
-    @Test
-    fun valueOf_accepts_uppercase_name() {
-        assertEquals(EventsFilter.Subscribed, EventsFilter.valueOf("Subscribed"))
-        assertEquals(EventsFilter.All, EventsFilter.valueOf("All"))
-    }
+  @Test
+  fun enum_constants_are_unique_instances() {
+    assertNotSame(EventsFilter.Subscribed, EventsFilter.All)
+  }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun valueOf_throws_for_invalid() {
-        EventsFilter.valueOf("NotAFilter")
-    }
+  private fun dbKeyFor(filter: EventsFilter): String =
+      when (filter) {
+        EventsFilter.Subscribed -> "only_subscribed"
+        EventsFilter.All -> "all_events"
+      }
 
+  @Test
+  fun when_exhaustive_branching_maps_expected_keys() {
+    assertEquals("only_subscribed", dbKeyFor(EventsFilter.Subscribed))
+    assertEquals("all_events", dbKeyFor(EventsFilter.All))
+  }
 
-    @Test
-    fun names_are_unique() {
-        val names = EventsFilter.entries.map { it.name }
-        assertEquals(names.size, names.distinct().size)
-    }
+  // --- Collections and lookup helpers ---
 
-    @Test
-    fun enum_constants_are_unique_instances() {
-        assertNotSame(EventsFilter.Subscribed, EventsFilter.All)
-    }
+  private fun findByNameOrNull(name: String): EventsFilter? =
+      EventsFilter.entries.firstOrNull { it.name.equals(name, ignoreCase = true) }
 
+  @Test
+  fun findByNameOrNull_finds_case_insensitively() {
+    assertEquals(EventsFilter.Subscribed, findByNameOrNull("subscribed"))
+    assertEquals(EventsFilter.All, findByNameOrNull("AlL"))
+  }
 
-    private fun dbKeyFor(filter: EventsFilter): String =
-        when (filter) {
-            EventsFilter.Subscribed -> "only_subscribed"
-            EventsFilter.All -> "all_events"
-        }
+  @Test
+  fun findByNameOrNull_returns_null_for_unknown() {
+    assertNull(findByNameOrNull("whatever"))
+  }
 
-    @Test
-    fun when_exhaustive_branching_maps_expected_keys() {
-        assertEquals("only_subscribed", dbKeyFor(EventsFilter.Subscribed))
-        assertEquals("all_events", dbKeyFor(EventsFilter.All))
-    }
+  // --- Defensive checks for future changes ---
 
-    // --- Collections and lookup helpers ---
-
-    private fun findByNameOrNull(name: String): EventsFilter? =
-        EventsFilter.entries.firstOrNull { it.name.equals(name, ignoreCase = true) }
-
-    @Test
-    fun findByNameOrNull_finds_case_insensitively() {
-        assertEquals(EventsFilter.Subscribed, findByNameOrNull("subscribed"))
-        assertEquals(EventsFilter.All, findByNameOrNull("AlL"))
-    }
-
-    @Test
-    fun findByNameOrNull_returns_null_for_unknown() {
-        assertNull(findByNameOrNull("whatever"))
-    }
-
-    // --- Defensive checks for future changes ---
-
-    @Test
-    fun adding_new_constants_should_break_this_guard() {
-        val guard = setOf(EventsFilter.Subscribed, EventsFilter.All)
-        val actual = EventsFilter.entries.toSet()
-        assertEquals(
-            "If this fails, update tests & business rules for new filters.",
-            guard,
-            actual
-        )
-    }
+  @Test
+  fun adding_new_constants_should_break_this_guard() {
+    val guard = setOf(EventsFilter.Subscribed, EventsFilter.All)
+    val actual = EventsFilter.entries.toSet()
+    assertEquals("If this fails, update tests & business rules for new filters.", guard, actual)
+  }
 }


### PR DESCRIPTION
This pull request adds a comprehensive unit test suite for two core enums: Category and EventsFilter.
The goal is to validate formatting behavior, enum integrity, and provide defensive guards for future changes. No production code was modified.

# Details
## CategoryTests

### Purpose: Ensure Category’s display and structure remain consistent.

###Covers:

- displayString() capitalization (Title Case, first letter only).
- No over-capitalization when already correct.
- Uniqueness and non-empty display strings.
- Enum integrity and ordering (expected constants & increasing ordinals).
- toString() equals enum name.
- Reversibility (displayString().uppercase() → valueOf).
- Defensive guard to fail if new constants are added without updating tests/UI.
- Edge checks (no underscores/digits, first char is a letter).
- Sanity mapping/iteration without errors.

## EventsFilterTest

### Purpose: Lock down the current two-filter model and its semantics.

### Covers:

- Enum contains exactly Subscribed and All (order & ordinals are stable).
- toString() defaults to name; valueOf(name) roundtrip.
- Case-insensitive lookup helpers.
- Exhaustive when mapping to expected keys (e.g., db keys).
- Defensive guard to fail if new constants are added without updating business rules.

## Notes

- No functional changes to app code; tests only.
-These tests act as change detectors: if enum members or formatting change, CI will surface it immediately.

## Coverage
<img width="606" height="32" alt="image" src="https://github.com/user-attachments/assets/d7729306-7549-47bd-9f96-6c9ab4a79a06" />
