### PR TITLE
Assemble tests in build task

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -250,3 +250,8 @@ configurations.forEach { configuration ->
     // This fixes a fatal exception for tests interacting with Cloud Firestore
     configuration.exclude("com.google.protobuf", "protobuf-lite")
 }
+
+tasks.named("build") {
+    dependsOn("assembleUnitTest")
+    dependsOn("assembleAndroidTest")
+}


### PR DESCRIPTION
When the `build` gradle task runs,
we don't actually notice if the compilation breaks, due to the fact, that the tests are not compiled.
This adds unit and android test compilation as dependencies to the build task, which will resolve this issue.

Resolves: #102 