### PR TITLE
Add sonar coverage path

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,6 +123,7 @@ sonar {
     property("sonar.projectKey", "EPFL-Life_life")
     property("sonar.organization", "epfl-life")
     property("sonar.host.url", "https://sonarcloud.io")
+    property("sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
   }
 }
 


### PR DESCRIPTION
Add path to jacoco coverage report to sonar config.

The hope is that this will fix our problems with sonar not recognizing the test coverage properly.