### PR TITLE
Add association card display tests

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/ui/composables/AssociationCardTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/composables/AssociationCardTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import ch.epfllife.model.association.Association
 import ch.epfllife.model.event.EventCategory
 import ch.epfllife.utils.assertClickable
+import ch.epfllife.utils.assertTagIsDisplayed
+import ch.epfllife.utils.assertTagTextEquals
 import org.junit.Rule
 import org.junit.Test
 
@@ -16,7 +18,8 @@ class AssociationCardTest {
           name = "Assoc",
           description = "This is a test event",
           eventCategory = EventCategory.TECH,
-          pictureUrl = null)
+          pictureUrl = null,
+      )
 
   @Test
   fun isClickable() {
@@ -24,5 +27,17 @@ class AssociationCardTest {
         { clickHandler -> AssociationCard(association, onClick = clickHandler) },
         AssociationCardTestTags.ASSOCIATION_CARD,
     )
+  }
+
+  @Test
+  fun contentIsDisplayed() {
+    composeTestRule.setContent { AssociationCard(association, onClick = {}) }
+
+    composeTestRule.assertTagTextEquals(AssociationCardTestTags.ASSOCIATION_NAME, association.name)
+    composeTestRule.assertTagTextEquals(
+        AssociationCardTestTags.ASSOCIATION_DESCRIPTION,
+        association.description,
+    )
+    composeTestRule.assertTagIsDisplayed(AssociationCardTestTags.ASSOCIATION_LOGO)
   }
 }

--- a/app/src/androidTest/java/ch/epfllife/utils/LifeTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/utils/LifeTest.kt
@@ -1,6 +1,8 @@
 package ch.epfllife.utils
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -21,4 +23,17 @@ fun ComposeContentTestRule.assertClickable(
   this.onNodeWithTag(tag).performClick()
 
   Assert.assertTrue("$tag should be clickable", clicked)
+}
+
+fun ComposeContentTestRule.assertTagIsDisplayed(tag: String) {
+  this.onNodeWithTag(tag, useUnmergedTree = true)
+      .assertExists("$tag must exist")
+      .assertIsDisplayed()
+}
+
+fun ComposeContentTestRule.assertTagTextEquals(tag: String, text: String) {
+  this.onNodeWithTag(tag, useUnmergedTree = true)
+      .assertExists("$tag must exist")
+      .assertIsDisplayed()
+      .assertTextEquals(text)
 }

--- a/app/src/main/java/ch/epfllife/ui/composables/AssociationCard.kt
+++ b/app/src/main/java/ch/epfllife/ui/composables/AssociationCard.kt
@@ -36,7 +36,10 @@ fun AssociationCard(association: Association, modifier: Modifier = Modifier, onC
               Image(
                   painter = painterResource(id = R.drawable.placeholder),
                   contentDescription = "${association.name} logo",
-                  modifier = Modifier.size(56.dp).align(Alignment.CenterVertically))
+                  modifier =
+                      Modifier.size(56.dp)
+                          .align(Alignment.CenterVertically)
+                          .testTag(AssociationCardTestTags.ASSOCIATION_LOGO))
 
               // Text section (name + description)
               Column(modifier = Modifier.weight(1f).align(Alignment.CenterVertically)) {
@@ -65,6 +68,7 @@ fun AssociationCard(association: Association, modifier: Modifier = Modifier, onC
 
 object AssociationCardTestTags {
   const val ASSOCIATION_CARD = "association_card"
+  const val ASSOCIATION_LOGO = "association_logo"
   const val ASSOCIATION_NAME = "association_name"
   const val ASSOCIATION_DESCRIPTION = "association_description"
 }


### PR DESCRIPTION
### Overview

Assert that the content of the association card
exists, is displayed and has the correct text.

### Notes

- This is a follow-up on #109.
- I plan on adding similar test for event cards, once #110 is merged.
- Thanks to @pukoa420 for figuring out the `unmergedTree = true`

Part of: #108 