### PR TITLE
Fix test timeout issues

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.kotlin.dsl.invoke
 import java.io.FileInputStream
 import java.util.Properties
 
@@ -204,6 +205,7 @@ dependencies {
     androidTestImplementation(libs.kaspresso.compose.support)
 
     testImplementation(libs.kotlinx.coroutines.test)
+    androidTestImplementation(libs.androidx.uiautomator)
 }
 
 

--- a/app/src/androidTest/java/ch/epfllife/ui/endToEnd/EndToEndTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/endToEnd/EndToEndTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.NoActivityResumedException
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import ch.epfllife.ThemedApp
 import ch.epfllife.ui.navigation.NavigationTestTags
 import ch.epfllife.ui.navigation.Tab
@@ -20,6 +22,13 @@ class EndToEndTest {
 
   @Before
   fun setup() {
+    // CI tests sometimes fail because of an open system dialog
+    // (likely caused through the fact that it runs too slow)
+    // This should fix it, by closing open system dialogs before starting the test.
+    // Source:
+    // https://stackoverflow.com/questions/39457305/android-testing-waited-for-the-root-of-the-view-hierarchy-to-have-window-focus
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        .executeShellCommand("am broadcast -a android.intent.action.CLOSE_SYSTEM_DIALOGS")
     composeTestRule.setContent { ThemedApp() }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ ktfmt = "0.17.0"
 # UI Compose
 mockitoAndroid = "5.13.0"
 ui = "1.6.8"
+uiautomator = "2.4.0-alpha06"
 uiTestJunit4 = "1.6.8"
 uiTestManifest = "1.6.8"
 uiTooling = "1.6.8"
@@ -90,6 +91,7 @@ androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", versi
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "uiTestManifest" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "uiTooling" }
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "ui" }
+androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 core-ktx = { module = "com.google.android.play:core-ktx", version.ref = "coreKtxVersion" }
 credentials = { module = "androidx.credentials:credentials", version.ref = "credentials" }


### PR DESCRIPTION
### Bug description

We can sometimes see the following issue in our CI runs:

```
ch.epfllife.ui.endToEnd.EndToEndTest > canExitWithBackPressFromHome[emulator-5554 - 14] FAILED 
	androidx.test.espresso.base.RootViewPicker$RootViewWithoutFocusException: Waited for the root of the view hierarchy to have window focus and not request layout for 10 seconds. If you specified a non default root matcher, it may be picking a root that never takes focus. Root:
	Root{application-window-token=android.view.ViewRootImpl$W@c1c2099, window-token=android.view.ViewRootImpl$W@c1c2099, has-window-focus=false, layout-params-type=1, layout-params-string={(0,0)(fillxfill) sim={forwardNavigation} ty=BASE_APPLICATION wanim=0x10302fe
```

The failing tests were introduced in #105, where they passed, after removing automations. But in subsequent PRs #138 and #111 we can see a regression. The root cause is most likely a too slow CI execution (the problem does usually not occur locally) which results in system dialogs opened by android. The fix closes those system dialogs automatically, such that the tests can proceed.

### Fix introduced

Following the advice of this [Stack overflow post](https://stackoverflow.com/questions/39457305/android-testing-waited-for-the-root-of-the-view-hierarchy-to-have-window-focus), I implemented the following changes:

- Add dependency for UIAutomator.
- Close system dialogs at test setup for end-to-end-tests.

Resolves: #145 