### PR TITLE
Feat: Add Tests for documentToEvent() Parser

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/model/event/EventRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/model/event/EventRepositoryFirestoreTest.kt
@@ -75,7 +75,7 @@ class EventRepositoryFirestoreTest {
   }
 
   @Test
-  fun documentToEvent_malformedLocation_returnsNull() {
+  fun documentToEvent_malformedId_returnsNull() {
 
     // arrange: mock the document
     whenever(mockDocument.id).thenReturn(null) // this will result in a parsing error

--- a/app/src/androidTest/java/ch/epfllife/model/event/EventRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/model/event/EventRepositoryFirestoreTest.kt
@@ -1,0 +1,97 @@
+package ch.epfllife.model.event
+
+import ch.epfllife.model.map.Location
+import com.google.firebase.firestore.DocumentSnapshot
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.whenever
+
+class EventRepositoryFirestoreTest {
+
+  // mock for the firebase class
+  @Mock private lateinit var mockDocument: DocumentSnapshot
+
+  // setup mock before tests
+  @Before
+  fun setup() {
+    MockitoAnnotations.openMocks(this)
+  }
+
+  @Test
+  fun documentToEvent_validDocument_returnsEvent() {
+
+    // arrange: mock the document
+    whenever(mockDocument.id).thenReturn("testId")
+    whenever(mockDocument.getString("title")).thenReturn("Test Event")
+    whenever(mockDocument.getString("description")).thenReturn("This is a test event")
+    whenever(mockDocument.get("location")).thenReturn(Location(1.0, 2.0, "Test Location"))
+    whenever(mockDocument.getString("time")).thenReturn("10:00")
+    whenever(mockDocument.getString("associationId")).thenReturn("testAssociationId")
+    whenever(mockDocument.get("tags")).thenReturn(listOf("tag1", "tag2"))
+    whenever(mockDocument.getLong("price")).thenReturn(100L)
+    whenever(mockDocument.getString("imageUrl")).thenReturn("testImageUrl")
+
+    // action: call the function
+    val event = EventRepositoryFirestore.documentToEvent(mockDocument)
+
+    // assert:
+    assert(event != null)
+    assertEquals("testId", event?.id)
+    assert("Test Event" == event?.title)
+    assert("This is a test event" == event?.description)
+    assert(1.0 == event?.location?.latitude)
+    assert(2.0 == event?.location?.longitude)
+    assert("Test Location" == event?.location?.name)
+    assert("10:00" == event?.time)
+    assert("testAssociationId" == event?.associationId)
+    assert(setOf("tag1", "tag2") == event?.tags)
+    assert(100u == event?.price)
+    assert("testImageUrl" == event?.imageUrl)
+  }
+
+  @Test
+  fun documentToEvent_missingRequiredField_returnsNull() {
+
+    // arrange: mock the document
+    whenever(mockDocument.id).thenReturn("testId")
+    whenever(mockDocument.getString("title")).thenReturn("Test Event")
+    whenever(mockDocument.getString("description")).thenReturn("This is a test event")
+    whenever(mockDocument.get("location")).thenReturn(Location(1.0, 2.0, "Test Location"))
+    whenever(mockDocument.getString("time")).thenReturn("10:00")
+    // associationId is "missing" therefore Mockito return null -> this will result in a parsing
+    // error
+    whenever(mockDocument.get("tags")).thenReturn(listOf("tag1", "tag2"))
+    whenever(mockDocument.getLong("price")).thenReturn(100L)
+    whenever(mockDocument.getString("imageUrl")).thenReturn("testImageUrl")
+
+    // action: call the function
+    val event = EventRepositoryFirestore.documentToEvent(mockDocument)
+
+    // assert: required field was missing therefore event should be null
+    assert(event == null)
+  }
+
+  @Test
+  fun documentToEvent_malformedLocation_returnsNull() {
+
+    // arrange: mock the document
+    whenever(mockDocument.id).thenReturn(null) // this will result in a parsing error
+    whenever(mockDocument.getString("title")).thenReturn("Test Event")
+    whenever(mockDocument.getString("description")).thenReturn("This is a test event")
+    whenever(mockDocument.getString("time")).thenReturn("10:00")
+    whenever(mockDocument.get("location")).thenReturn(Location(1.0, 2.0, "Test Location"))
+    whenever(mockDocument.getString("associationId")).thenReturn("testAssociationId")
+    whenever(mockDocument.get("tags")).thenReturn(listOf("tag1", "tag2"))
+    whenever(mockDocument.getLong("price")).thenReturn(-100L)
+    whenever(mockDocument.getString("imageUrl")).thenReturn("testImageUrl")
+
+    // action: call the function
+    val event = EventRepositoryFirestore.documentToEvent(mockDocument)
+
+    // assert: event should be null
+    assert(event == null)
+  }
+}

--- a/app/src/androidTest/java/ch/epfllife/model/event/EventRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/model/event/EventRepositoryFirestoreTest.kt
@@ -1,6 +1,5 @@
 package ch.epfllife.model.event
 
-import ch.epfllife.model.map.Location
 import com.google.firebase.firestore.DocumentSnapshot
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -20,6 +19,11 @@ class EventRepositoryFirestoreTest {
     MockitoAnnotations.openMocks(this)
   }
 
+  /** Helper function to create the nested location map */
+  private fun createLocationMap(lat: Double, lon: Double, name: String): Map<String, Any> {
+    return mapOf("latitude" to lat, "longitude" to lon, "name" to name)
+  }
+
   @Test
   fun documentToEvent_validDocument_returnsEvent() {
 
@@ -27,7 +31,7 @@ class EventRepositoryFirestoreTest {
     whenever(mockDocument.id).thenReturn("testId")
     whenever(mockDocument.getString("title")).thenReturn("Test Event")
     whenever(mockDocument.getString("description")).thenReturn("This is a test event")
-    whenever(mockDocument.get("location")).thenReturn(Location(1.0, 2.0, "Test Location"))
+    whenever(mockDocument.get("location")).thenReturn(createLocationMap(1.0, 2.0, "Test Location"))
     whenever(mockDocument.getString("time")).thenReturn("10:00")
     whenever(mockDocument.getString("associationId")).thenReturn("testAssociationId")
     whenever(mockDocument.get("tags")).thenReturn(listOf("tag1", "tag2"))
@@ -59,7 +63,7 @@ class EventRepositoryFirestoreTest {
     whenever(mockDocument.id).thenReturn("testId")
     whenever(mockDocument.getString("title")).thenReturn("Test Event")
     whenever(mockDocument.getString("description")).thenReturn("This is a test event")
-    whenever(mockDocument.get("location")).thenReturn(Location(1.0, 2.0, "Test Location"))
+    whenever(mockDocument.get("location")).thenReturn(createLocationMap(3.0, 4.0, "Test Location2"))
     whenever(mockDocument.getString("time")).thenReturn("10:00")
     // associationId is "missing" therefore Mockito return null -> this will result in a parsing
     // error
@@ -82,7 +86,7 @@ class EventRepositoryFirestoreTest {
     whenever(mockDocument.getString("title")).thenReturn("Test Event")
     whenever(mockDocument.getString("description")).thenReturn("This is a test event")
     whenever(mockDocument.getString("time")).thenReturn("10:00")
-    whenever(mockDocument.get("location")).thenReturn(Location(1.0, 2.0, "Test Location"))
+    whenever(mockDocument.get("location")).thenReturn(createLocationMap(5.0, 6.0, "Test Location3"))
     whenever(mockDocument.getString("associationId")).thenReturn("testAssociationId")
     whenever(mockDocument.get("tags")).thenReturn(listOf("tag1", "tag2"))
     whenever(mockDocument.getLong("price")).thenReturn(-100L)


### PR DESCRIPTION
Added tests to verify documentToEvent() works as intended and to increase code coverage.

**Test cases:**
- successful parsing of valid documentSnapshot returns parsed Event object
- missing required field return null
- invalid id resulting in a parsing error returns null

**Approach:**
We moch the DocumentSnapshot we would receive from Firestore and assert what we would expect according to 1 of the 3 cases.

documentToEvent() docs:
<img width="771" height="302" alt="image" src="https://github.com/user-attachments/assets/b8bc87bc-fc91-483f-bdff-8955ae36e06c" />
