### PR TITLE
Location accepts long for lat and lng

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/model/map/LocationTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/model/map/LocationTest.kt
@@ -29,4 +29,11 @@ class LocationTest {
     }
     assertThrows(IllegalArgumentException::class.java) { Location(Any(), Any()) }
   }
+
+  @Test
+  fun boxed_double_values_via_Any_are_handled() {
+    val loc = Location(1.23 as Any, 4.56 as Any)
+    assertEquals(1.23, loc.latitude, 1e-9)
+    assertEquals(4.56, loc.longitude, 1e-9)
+  }
 }

--- a/app/src/androidTest/java/ch/epfllife/model/map/LocationTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/model/map/LocationTest.kt
@@ -1,0 +1,32 @@
+package ch.epfllife.model.map
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class LocationTest {
+
+  @Test
+  fun number_types_are_converted_to_double() {
+    val loc = Location(10, 20f) // Int and Float
+    assertEquals(10.0, loc.latitude, 1e-9)
+    assertEquals(20.0, loc.longitude, 1e-9)
+    assertEquals("", loc.name)
+  }
+
+  @Test
+  fun double_values_are_preserved_and_name() {
+    val loc = Location(1.23, 4.56, "here")
+    assertEquals(1.23, loc.latitude, 1e-9)
+    assertEquals(4.56, loc.longitude, 1e-9)
+    assertEquals("here", loc.name)
+  }
+
+  @Test
+  fun unsupported_types_throw_IllegalArgumentException() {
+    assertThrows(IllegalArgumentException::class.java) {
+      Location("1.0", "2.0") // String is unsupported in current implementation
+    }
+    assertThrows(IllegalArgumentException::class.java) { Location(Any(), Any()) }
+  }
+}

--- a/app/src/main/java/ch/epfllife/model/map/Location.kt
+++ b/app/src/main/java/ch/epfllife/model/map/Location.kt
@@ -4,4 +4,20 @@ data class Location(
     val latitude: Double,
     val longitude: Double,
     val name: String,
-)
+) {
+  constructor(
+      latitude: Any,
+      longitude: Any,
+      name: String = ""
+  ) : this(parseDouble(latitude, "latitude"), parseDouble(longitude, "longitude"), name)
+
+  companion object {
+    private fun parseDouble(value: Any, fieldName: String): Double {
+      return when (value) {
+        is Double -> value
+        is Number -> value.toDouble()
+        else -> throw IllegalArgumentException("$fieldName has unsupported type: ${value::class}")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes a problem where long could not be casted to double. This was a problem when latitude or longitude was a whole number in firebase.