### PR TITLE
Enroll events (firebase repository) + tests 

### DIFF
--- a/app/src/main/java/ch/epfllife/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/ch/epfllife/model/user/UserRepositoryFirestore.kt
@@ -144,22 +144,21 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore) : UserRepositor
     val currentUser = getCurrentUser()
 
     // case 1: getCurrentUser() returns a null object
-    if(currentUser==null){
-      return Result.failure(
-        NoSuchElementException("No user is currently logged in"))
+    if (currentUser == null) {
+      return Result.failure(NoSuchElementException("No user is currently logged in"))
     }
 
     // case 2: event doesn't exist
     val event = db.collection(FirestoreCollections.EVENTS).document(eventId).get().await()
-    if(!event.exists()){
+    if (!event.exists()) {
       return Result.failure(
-        NoSuchElementException("Event with ID $eventId does not exist in the repository.")
-      )
+          NoSuchElementException("Event with ID $eventId does not exist in the repository."))
     }
 
     // case 3: user has already enrolled to event
     if (currentUser.enrolledEvents.contains(eventId)) {
-      return Result.failure(IllegalArgumentException("User is already subscribed to event with ID: $eventId"))
+      return Result.failure(
+          IllegalArgumentException("User is already subscribed to event with ID: $eventId"))
     }
 
     // case 4: user can enroll
@@ -167,29 +166,28 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore) : UserRepositor
     // we proceed to update the list of enrolled events
     val updatedUser = currentUser.copy(enrolledEvents = currentUser.enrolledEvents + eventId)
     // finally we update the user with the new list
-    return updateUser(currentUser.id, updatedUser )
+    return updateUser(currentUser.id, updatedUser)
   }
 
   override suspend fun unsubscribeFromEvent(eventId: String): Result<Unit> {
     val currentUser = getCurrentUser()
 
     // case 1: getCurrentUser() returns a null object
-    if(currentUser==null){
-      return Result.failure(
-        NoSuchElementException("No user is currently logged in"))
+    if (currentUser == null) {
+      return Result.failure(NoSuchElementException("No user is currently logged in"))
     }
 
     // case 2: event doesn't exist
     val event = db.collection(FirestoreCollections.EVENTS).document(eventId).get().await()
-    if(!event.exists()){
+    if (!event.exists()) {
       return Result.failure(
-        NoSuchElementException("Event with ID $eventId does not exist in the repository.")
-      )
+          NoSuchElementException("Event with ID $eventId does not exist in the repository."))
     }
 
     // case 3: the user is trying to unsubscribe from an event they are not subscribed to
     if (!currentUser.enrolledEvents.contains(eventId)) {
-      return Result.failure(IllegalArgumentException("User is not subscribed to event with ID: $eventId"))
+      return Result.failure(
+          IllegalArgumentException("User is not subscribed to event with ID: $eventId"))
     }
 
     // case 4: user can enroll
@@ -197,6 +195,6 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore) : UserRepositor
     // we proceed to update the list of enrolled events
     val updatedUser = currentUser.copy(enrolledEvents = currentUser.enrolledEvents - eventId)
     // finally we update the user with the new list
-    return updateUser(currentUser.id, updatedUser )
+    return updateUser(currentUser.id, updatedUser)
   }
 }


### PR DESCRIPTION
In this PR I've implemented the functionality of enrolling and unrolling from a firebase repository event

## Changes
-  **subscribeToEvent()** and **unsubscribeFromEvent()** methods from UserRepositoryFirbase have been implemented
- Add their respective tests in **UserRepositoryFirebaseTest()**. Note that I created an helper function to simulate an uthenticated user. For testing the tests effectively and simply, the autheticated user's id has been copy to one of the example users to force that the users is the same as the authenticated.

Coverage:
<img width="1420" height="510" alt="image" src="https://github.com/user-attachments/assets/053821be-aa56-4737-9b93-58d82f2737fe" />

