### PR TITLE
Fix/Feat: actually retrive associations from firebase 

### DIFF
--- a/app/src/main/java/ch/epfllife/ui/association/AssociationBrowser.kt
+++ b/app/src/main/java/ch/epfllife/ui/association/AssociationBrowser.kt
@@ -13,10 +13,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.epfllife.R
-import ch.epfllife.model.association.Association
 import ch.epfllife.model.enums.SubscriptionFilter
-import ch.epfllife.model.event.EventCategory
 import ch.epfllife.ui.composables.AssociationCard
 import ch.epfllife.ui.composables.DisplayedSubscriptionFilter
 import ch.epfllife.ui.composables.SearchBar
@@ -25,28 +24,14 @@ import ch.epfllife.ui.navigation.NavigationTestTags
 @Composable
 fun AssociationBrowser(
     modifier: Modifier = Modifier,
+    viewModel: AssociationBrowserViewModel = viewModel(),
     onAssociationClick: (associationId: String) -> Unit
 ) {
   var selected by remember { mutableStateOf(SubscriptionFilter.Subscribed) }
-  val subscribedAssociations = remember {
-    emptyList<Association>()
-  } // No Associations to show empty state
 
-  val allAssociations = remember {
-    listOf(
-        Association(
-            id = "1",
-            name = "ESN Lausanne",
-            description = "Erasmus Student Network at EPFL.",
-            pictureUrl = null,
-            eventCategory = EventCategory.CULTURE),
-        Association(
-            id = "2",
-            name = "EPFL Sports Club",
-            description = "Join for weekly sports activities and tournaments.",
-            pictureUrl = null,
-            eventCategory = EventCategory.SPORTS))
-  }
+  // Replaced hardcoded lists with data from ViewModel
+  val subscribedAssociations by viewModel.subscribedAssociations.collectAsState()
+  val allAssociations by viewModel.allAssociations.collectAsState()
 
   val shownAssociations =
       if (selected == SubscriptionFilter.Subscribed) subscribedAssociations else allAssociations

--- a/app/src/main/java/ch/epfllife/ui/association/AssociationBrowserViewModel.kt
+++ b/app/src/main/java/ch/epfllife/ui/association/AssociationBrowserViewModel.kt
@@ -1,0 +1,54 @@
+package ch.epfllife.ui.association
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import ch.epfllife.model.association.Association
+import ch.epfllife.model.association.AssociationRepository
+import ch.epfllife.model.association.AssociationRepositoryFirestore
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for the AssociationBrowser screen.
+ *
+ * @param repo The repository to fetch associations from.
+ */
+class AssociationBrowserViewModel(
+    private val repo: AssociationRepository =
+        AssociationRepositoryFirestore(FirebaseFirestore.getInstance())
+) : ViewModel() {
+
+  private val _allAssociations = MutableStateFlow<List<Association>>(emptyList())
+  val allAssociations: StateFlow<List<Association>> = _allAssociations.asStateFlow()
+
+  // TODO: Implement logic to load *only* subscribed associations (e.g., from UserRepository)
+  private val _subscribedAssociations = MutableStateFlow<List<Association>>(emptyList())
+  val subscribedAssociations: StateFlow<List<Association>> = _subscribedAssociations.asStateFlow()
+
+  init {
+    loadAllAssociations()
+    // TODO: Also load subscribed associations when user data is available
+  }
+
+  /** Fetches all associations from the repository and updates the [allAssociations] state. */
+  private fun loadAllAssociations() {
+    viewModelScope.launch {
+      _allAssociations.value =
+          try {
+            repo.getAllAssociations()
+          } catch (e: Exception) {
+            // Log the error or handle it as needed
+            // e.g., Log.e("AssociationBrowserVM", "Failed to load associations", e)
+            emptyList() // Return an empty list on failure
+          }
+    }
+  }
+
+  // TODO: Add a function to load subscribed associations
+  // This will likely require a UserRepository to know which associations
+  // the current user is subscribed to. For now, it remains an empty list,
+  // matching the original hardcoded behavior for "Subscribed".
+}


### PR DESCRIPTION
We used hardcoded associatioons till now.

**Changes:**
- implemented AssociationBrowserViewModel with logic to retreive all data
- connected AssociationBrowser to AssociationBrowserViewModel

**TODO:**
- implement the logic to retive **only** the subscribed events (@Adriv020)