### PR TITLE
Remove dependency on viewModel for EventDetailsContent

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.epfllife.model.association.Association
 import ch.epfllife.model.event.Event
 import ch.epfllife.model.event.EventCategory
@@ -54,8 +53,7 @@ class EventDetailsScreenTest {
 
     composeTestRule.setContent {
       Theme {
-        EventDetailsContent(
-            event = sampleEvent, onGoBack = {}, onOpenMap = {}, viewModel = viewModel())
+        EventDetailsContent(event = sampleEvent, onGoBack = {}, onOpenMap = {}, onEnrollClick = {})
       }
     }
   }

--- a/app/src/androidTest/java/ch/epfllife/ui/eventdetails/EventDetailsTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/eventdetails/EventDetailsTest.kt
@@ -2,7 +2,6 @@ package ch.epfllife.ui.eventdetails
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.epfllife.model.association.Association
 import ch.epfllife.model.event.Event
 import ch.epfllife.model.event.EventCategory
@@ -69,7 +68,7 @@ class EventDetailsTest {
 
   private fun setEventContent(event: Event) {
     composeTestRule.setContent {
-      EventDetailsContent(event = event, viewModel = viewModel(), onOpenMap = {})
+      EventDetailsContent(event = event, onOpenMap = {}, onGoBack = {}, onEnrollClick = {})
     }
   }
 
@@ -282,7 +281,7 @@ class EventDetailsTest {
     var clicked = false
     composeTestRule.setContent {
       EventDetailsContent(
-          sampleEvent, onGoBack = {}, onOpenMap = { clicked = true }, viewModel = viewModel())
+          sampleEvent, onGoBack = {}, onOpenMap = { clicked = true }, onEnrollClick = {})
     }
     composeTestRule
         .onNodeWithTag(EventDetailsTestTags.VIEW_LOCATION_BUTTON)
@@ -298,7 +297,7 @@ class EventDetailsTest {
       EventDetailsContent(
           event = sampleEvent,
           onGoBack = { backClicked = true },
-          viewModel = viewModel(),
+          onEnrollClick = {},
           onOpenMap = {})
     }
     composeTestRule.onNodeWithTag(EventDetailsTestTags.BACK_BUTTON).performClick()
@@ -433,14 +432,10 @@ class EventDetailsTest {
   @Test
   fun integration_MultipleClicksOnEnrollButton() {
     var clickCount = 0
-    val testViewModel = EventDetailsViewModel()
 
     composeTestRule.setContent {
       EventDetailsContent(
-          event = sampleEvent,
-          viewModel = testViewModel,
-          onGoBack = { clickCount++ },
-          onOpenMap = {})
+          event = sampleEvent, onEnrollClick = {}, onGoBack = { clickCount++ }, onOpenMap = {})
     }
 
     // Click enroll button multiple times
@@ -460,7 +455,7 @@ class EventDetailsTest {
       EventDetailsContent(
           event = sampleEvent,
           onGoBack = { goBackCalled = true },
-          viewModel = viewModel(),
+          onEnrollClick = {},
           onOpenMap = {})
     }
 

--- a/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
@@ -88,7 +88,7 @@ fun EventDetailsScreen(
           event = state.event,
           onGoBack = onGoBack,
           onOpenMap = onOpenMap,
-          viewModel = viewModel,
+          onEnrollClick = { viewModel.enrollInEvent(state.event) },
       )
     }
   }
@@ -98,9 +98,9 @@ fun EventDetailsScreen(
 fun EventDetailsContent(
     event: Event,
     modifier: Modifier = Modifier,
-    onGoBack: () -> Unit = {},
+    onGoBack: () -> Unit,
     onOpenMap: (Location) -> Unit,
-    viewModel: EventDetailsViewModel,
+    onEnrollClick: () -> Unit,
 ) {
   val context = LocalContext.current
   Column(
@@ -255,7 +255,7 @@ fun EventDetailsContent(
           // TODO: button should be gray and say "Enrolled" if user already enrolled -> create a
           // isEnrolled fun in viewModel
           Button(
-              onClick = { viewModel.enrollInEvent(event) },
+              onClick = onEnrollClick,
               modifier =
                   Modifier.fillMaxWidth()
                       .padding(top = 8.dp)
@@ -299,5 +299,7 @@ fun EventDetailsPreview() {
               "https://www.shutterstock.com/image-photo/engineer-working-on-racing-fpv-600nw-2278353271.jpg",
       )
 
-  Theme() { EventDetailsContent(event = sampleEvent, viewModel = viewModel(), onOpenMap = {}) }
+  Theme() {
+    EventDetailsContent(event = sampleEvent, onOpenMap = {}, onGoBack = {}, onEnrollClick = {})
+  }
 }


### PR DESCRIPTION
Pass a callback instead of the view model
for the EventDetailsContent to prevent state inconsistencies (can happen when re-rendering things).

The EventDetailsContent expects the viewmodel to be in the success state,
but we cannot encode that in the type system.
Passing parameters makes the content independent of the viewmodel's state.

This is a pre-requisite for #197