### PR TITLE
Disable the compass on mapScreen

### DIFF
--- a/app/src/main/java/ch/epfllife/ui/composables/Map.kt
+++ b/app/src/main/java/ch/epfllife/ui/composables/Map.kt
@@ -37,7 +37,6 @@ fun Map(
     target: Location,
     enableControls: Boolean,
     locationPermissionRequest: @Composable ((Boolean) -> Unit) -> Unit,
-    compassEnabled: Boolean = enableControls,
 ) {
   val targetPos = LatLng(target.latitude, target.longitude)
   val cameraStartPos = CameraPosition.fromLatLngZoom(targetPos, 15f)
@@ -57,7 +56,7 @@ fun Map(
       uiSettings =
           MapUiSettings(
               myLocationButtonEnabled = showLocationControls,
-              compassEnabled = compassEnabled,
+              compassEnabled = false,
               zoomControlsEnabled = enableControls,
               scrollGesturesEnabled = enableControls,
               zoomGesturesEnabled = enableControls,

--- a/app/src/main/java/ch/epfllife/ui/eventDetails/MapScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/eventDetails/MapScreen.kt
@@ -23,7 +23,6 @@ fun MapScreen(location: Location, onGoBack: () -> Unit) {
         target = location,
         enableControls = true,
         locationPermissionRequest = { LocationPermissionRequest(it) },
-        compassEnabled = false, // Disable compass to avoid overlap with back button
     )
     BackButton(
         modifier = Modifier.align(Alignment.TopStart).testTag(MapScreenTestTags.BACK_BUTTON),


### PR DESCRIPTION
This PR disables the compass on the MapScreen.kt as it was overlaying with the back button before. 

Since we cannot move the position of the compass on the google maps API, we have decided to just disable it as it is not required.

I considered removing the ability to rotate the map (the EPFL campus app does this), but I realised this would be annoying for users and decided against it. 
I also considered moving the back button's position down slightly on the page so it was just below the compass, but this would mess with the consistency across the app. 