### PR TITLE
Allow back button to overlay on details pages.

### DIFF
--- a/app/src/main/java/ch/epfllife/ui/association/AssociationDetailsScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/association/AssociationDetailsScreen.kt
@@ -89,172 +89,167 @@ fun AssociationDetailsContent(
   val scrollState = rememberScrollState()
   val context = LocalContext.current
 
-  Column(
-      modifier =
-          modifier
-              .fillMaxSize()
-              .verticalScroll(scrollState)
-              .background(MaterialTheme.colorScheme.surface)) {
-        // Header Image
-        Box(modifier = Modifier.fillMaxWidth()) {
-          AsyncImage(
-              model =
-                  ImageRequest.Builder(LocalContext.current)
-                      .data(association.pictureUrl)
-                      .crossfade(true)
-                      .build(),
-              contentDescription = stringResource(R.string.association_image_description),
-              contentScale = ContentScale.Crop,
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .height(240.dp)
-                      .clip(RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp))
-                      .testTag(AssociationDetailsTestTags.ASSOCIATION_IMAGE),
-          )
+  Box(modifier = modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
+    // Header Image
+    Column(modifier = Modifier.fillMaxWidth().verticalScroll(scrollState)) {
+      Box(modifier = Modifier.fillMaxWidth()) {
+        AsyncImage(
+            model =
+                ImageRequest.Builder(LocalContext.current)
+                    .data(association.pictureUrl)
+                    .crossfade(true)
+                    .build(),
+            contentDescription = stringResource(R.string.association_image_description),
+            contentScale = ContentScale.Crop,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .height(240.dp)
+                    .clip(RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp))
+                    .testTag(AssociationDetailsTestTags.ASSOCIATION_IMAGE),
+        )
+      }
 
-          BackButton(
-              modifier =
-                  Modifier.align(Alignment.TopStart)
-                      .testTag(AssociationDetailsTestTags.BACK_BUTTON),
-              onGoBack = onGoBack,
-          )
-        }
+      // Content Below Header
+      Column(
+          modifier = Modifier.fillMaxWidth().padding(16.dp),
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        Text(
+            text = association.name,
+            style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+            modifier = Modifier.testTag(AssociationDetailsTestTags.NAME_TEXT),
+        )
+        Text(
+            text = association.description,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.testTag(AssociationDetailsTestTags.DESCRIPTION_TEXT),
+        )
 
-        // Content Below Header
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+        // Subscribe Button
+        val subscribeButtonTag =
+            if (isSubscribed) {
+              AssociationDetailsTestTags.UNSUBSCRIBE_BUTTON
+            } else {
+              AssociationDetailsTestTags.SUBSCRIBE_BUTTON
+            }
+
+        Button(
+            onClick = { isSubscribed = !isSubscribed },
+            modifier = Modifier.fillMaxWidth().testTag(subscribeButtonTag),
+            shape = RoundedCornerShape(6.dp),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = if (isSubscribed) Color.Gray else LifeRed,
+                    contentColor = Color.White,
+                ),
         ) {
           Text(
-              text = association.name,
-              style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-              modifier = Modifier.testTag(AssociationDetailsTestTags.NAME_TEXT),
+              text =
+                  if (isSubscribed) stringResource(R.string.unsubscribe_from, association.name)
+                  else stringResource(R.string.subscribe_to, association.name))
+        }
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+
+        // About Section
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.testTag(AssociationDetailsTestTags.ABOUT_SECTION),
+        ) {
+          Text(
+              stringResource(R.string.about_section_title),
+              style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
           )
           Text(
-              text = association.description,
+              association.about ?: stringResource(R.string.about_placeholder),
               style = MaterialTheme.typography.bodyMedium,
-              color = MaterialTheme.colorScheme.onSurfaceVariant,
-              modifier = Modifier.testTag(AssociationDetailsTestTags.DESCRIPTION_TEXT),
+          )
+        }
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+
+        // Social Pages
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          Text(
+              stringResource(R.string.social_pages_title),
+              style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
           )
 
-          // Subscribe Button
-          val subscribeButtonTag =
-              if (isSubscribed) {
-                AssociationDetailsTestTags.UNSUBSCRIBE_BUTTON
-              } else {
-                AssociationDetailsTestTags.SUBSCRIBE_BUTTON
-              }
-
-          Button(
-              onClick = { isSubscribed = !isSubscribed },
-              modifier = Modifier.fillMaxWidth().testTag(subscribeButtonTag),
-              shape = RoundedCornerShape(6.dp),
-              colors =
-                  ButtonDefaults.buttonColors(
-                      containerColor = if (isSubscribed) Color.Gray else LifeRed,
-                      contentColor = Color.White,
-                  ),
+          Row(
+              horizontalArrangement = Arrangement.spacedBy(24.dp),
+              verticalAlignment = Alignment.CenterVertically,
+              modifier = Modifier.testTag(AssociationDetailsTestTags.SOCIAL_LINKS_ROW),
           ) {
-            Text(
-                text =
-                    if (isSubscribed) stringResource(R.string.unsubscribe_from, association.name)
-                    else stringResource(R.string.subscribe_to, association.name))
-          }
-
-          HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
-
-          // About Section
-          Column(
-              verticalArrangement = Arrangement.spacedBy(8.dp),
-              modifier = Modifier.testTag(AssociationDetailsTestTags.ABOUT_SECTION),
-          ) {
-            Text(
-                stringResource(R.string.about_section_title),
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-            )
-            Text(
-                association.about ?: stringResource(R.string.about_placeholder),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-          }
-
-          HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
-
-          // Social Pages
-          Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(
-                stringResource(R.string.social_pages_title),
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-            )
-
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(24.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.testTag(AssociationDetailsTestTags.SOCIAL_LINKS_ROW),
-            ) {
-              association.socialLinks
-                  ?.toList()
-                  ?.sortedBy { (platform, _) ->
-                    SocialIcons.platformOrder.indexOf(platform.lowercase()).takeIf { it >= 0 }
-                        ?: Int.MAX_VALUE
-                  }
-                  ?.forEach { (platform, url) ->
-                    val iconRes = SocialIcons.getIcon(platform) ?: R.drawable.ic_default
-                    IconButton(
-                        onClick = {
-                          val intent = Intent(Intent.ACTION_VIEW, url.toUri())
-                          context.startActivity(intent)
-                        }) {
-                          Icon(
-                              painter = painterResource(id = iconRes),
-                              contentDescription = platform,
-                              tint = Color.Unspecified,
-                              modifier = Modifier.size(32.dp),
-                          )
-                        }
-                  }
-            }
-          }
-
-          HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
-
-          // Upcoming Events (dummy data)
-          Column(
-              verticalArrangement = Arrangement.spacedBy(12.dp),
-              modifier = Modifier.testTag(AssociationDetailsTestTags.UPCOMING_EVENTS_COLUMN),
-          ) {
-            Text(
-                stringResource(R.string.upcoming_events_title),
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-            )
-
-            val dummyEvents =
-                listOf(
-                    Event(
-                        id = "1",
-                        title = "Welcome Party",
-                        description = "Kick off the semester with music and fun.",
-                        location = Location(46.5191, 6.5668, "EPFL Esplanade"),
-                        time = "2025-10-20 18:00",
-                        association = association,
-                        tags = listOf("party"),
-                        price = Price(0u),
-                        pictureUrl = null),
-                    Event(
-                        id = "2",
-                        title = "Hiking Trip",
-                        description = "Join us for a scenic hike in the mountains.",
-                        location = Location(46.2, 7.0, "Les Pleiades"),
-                        time = "2025-11-02 09:00",
-                        association = association,
-                        tags = listOf("outdoors"),
-                        price = Price(15u),
-                        pictureUrl = null))
-
-            dummyEvents.forEach { event -> EventCard(event = event, onClick = {}) }
+            association.socialLinks
+                ?.toList()
+                ?.sortedBy { (platform, _) ->
+                  SocialIcons.platformOrder.indexOf(platform.lowercase()).takeIf { it >= 0 }
+                      ?: Int.MAX_VALUE
+                }
+                ?.forEach { (platform, url) ->
+                  val iconRes = SocialIcons.getIcon(platform) ?: R.drawable.ic_default
+                  IconButton(
+                      onClick = {
+                        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
+                        context.startActivity(intent)
+                      }) {
+                        Icon(
+                            painter = painterResource(id = iconRes),
+                            contentDescription = platform,
+                            tint = Color.Unspecified,
+                            modifier = Modifier.size(32.dp),
+                        )
+                      }
+                }
           }
         }
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+
+        // Upcoming Events (dummy data)
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.testTag(AssociationDetailsTestTags.UPCOMING_EVENTS_COLUMN),
+        ) {
+          Text(
+              stringResource(R.string.upcoming_events_title),
+              style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+          )
+
+          val dummyEvents =
+              listOf(
+                  Event(
+                      id = "1",
+                      title = "Welcome Party",
+                      description = "Kick off the semester with music and fun.",
+                      location = Location(46.5191, 6.5668, "EPFL Esplanade"),
+                      time = "2025-10-20 18:00",
+                      association = association,
+                      tags = listOf("party"),
+                      price = Price(0u),
+                      pictureUrl = null),
+                  Event(
+                      id = "2",
+                      title = "Hiking Trip",
+                      description = "Join us for a scenic hike in the mountains.",
+                      location = Location(46.2, 7.0, "Les Pleiades"),
+                      time = "2025-11-02 09:00",
+                      association = association,
+                      tags = listOf("outdoors"),
+                      price = Price(15u),
+                      pictureUrl = null))
+
+          dummyEvents.forEach { event -> EventCard(event = event, onClick = {}) }
+        }
       }
+    }
+    BackButton(
+        modifier =
+            Modifier.align(Alignment.TopStart).testTag(AssociationDetailsTestTags.BACK_BUTTON),
+        onGoBack = onGoBack,
+    )
+  }
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
@@ -105,174 +105,173 @@ fun EventDetailsContent(
     onEnrollClick: () -> Unit,
 ) {
   val context = LocalContext.current
-  Column(
+  Box(
       modifier =
           modifier
               .fillMaxSize()
               .background(MaterialTheme.colorScheme.surface)
-              .verticalScroll(rememberScrollState())
               .testTag(EventDetailsTestTags.CONTENT)) {
 
         // Header with image and overlayed back button
-        Box(modifier = Modifier.fillMaxWidth()) {
-          AsyncImage(
-              model =
-                  ImageRequest.Builder(context)
-                      .data(
-                          event.pictureUrl
-                              ?: "https://www.epfl.ch/campus/services/events/wp-content/uploads/2024/09/WEB_Image-Home-Events_ORGANISER.png")
-                      .crossfade(true)
-                      .build(),
-              contentDescription = "Event Image",
+        Column(modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState())) {
+          Box(modifier = Modifier.fillMaxWidth()) {
+            AsyncImage(
+                model =
+                    ImageRequest.Builder(context)
+                        .data(
+                            event.pictureUrl
+                                ?: "https://www.epfl.ch/campus/services/events/wp-content/uploads/2024/09/WEB_Image-Home-Events_ORGANISER.png")
+                        .crossfade(true)
+                        .build(),
+                contentDescription = "Event Image",
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .height(260.dp)
+                        .clip(RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp))
+                        .testTag(EventDetailsTestTags.EVENT_IMAGE),
+                contentScale = ContentScale.Crop,
+            )
+          }
+
+          // Start of Text Information
+          Column(
               modifier =
                   Modifier.fillMaxWidth()
-                      .height(260.dp)
-                      .clip(RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp))
-                      .testTag(EventDetailsTestTags.EVENT_IMAGE),
-              contentScale = ContentScale.Crop,
-          )
-
-          // Back Arrow on top of the picture (as in Mockup)
-          BackButton(
-              modifier =
-                  Modifier.align(Alignment.TopStart).testTag(EventDetailsTestTags.BACK_BUTTON),
-              onGoBack = onGoBack,
-          )
-        }
-
-        // Start of Text Information
-        Column(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .padding(16.dp)
-                    .background(MaterialTheme.colorScheme.surface),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-          // Row containing: Title, Club, Price
-          Row(
-              modifier = Modifier.fillMaxWidth(),
-              horizontalArrangement = Arrangement.SpaceBetween) {
-                Column {
+                      .padding(16.dp)
+                      .background(MaterialTheme.colorScheme.surface),
+              verticalArrangement = Arrangement.spacedBy(16.dp),
+          ) {
+            // Row containing: Title, Club, Price
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween) {
+                  Column {
+                    Text(
+                        text = event.title,
+                        style =
+                            MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.testTag(EventDetailsTestTags.EVENT_TITLE),
+                    )
+                    Text(
+                        text = event.association.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.testTag(EventDetailsTestTags.EVENT_ASSOCIATION),
+                    )
+                  }
                   Text(
-                      text = event.title,
+                      text = event.price.let { "$it" },
                       style =
-                          MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                          MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Medium),
                       color = MaterialTheme.colorScheme.onSurface,
-                      modifier = Modifier.testTag(EventDetailsTestTags.EVENT_TITLE),
-                  )
-                  Text(
-                      text = event.association.name,
-                      style = MaterialTheme.typography.bodyMedium,
-                      color = MaterialTheme.colorScheme.onSurfaceVariant,
-                      modifier = Modifier.testTag(EventDetailsTestTags.EVENT_ASSOCIATION),
+                      modifier = Modifier.testTag(EventDetailsTestTags.EVENT_PRICE),
                   )
                 }
-                Text(
-                    text = event.price.let { "$it" },
-                    style =
-                        MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Medium),
-                    color = MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.testTag(EventDetailsTestTags.EVENT_PRICE),
-                )
-              }
 
-          // Row containing: Date, Time, Location
-          // TODO-question: make this clickable to be displayed in Calender?
-          Row(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .clip(RoundedCornerShape(8.dp))
-                      .background(MaterialTheme.colorScheme.surfaceVariant)
-                      .padding(12.dp),
-              horizontalArrangement = Arrangement.SpaceBetween,
-              verticalAlignment = Alignment.CenterVertically,
-          ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-              Icon(
-                  imageVector = Icons.Default.CalendarToday,
-                  contentDescription = "Date",
-                  tint = MaterialTheme.colorScheme.onSurfaceVariant,
-              )
-              Spacer(modifier = Modifier.width(8.dp))
-              Column {
-                Text(
-                    text = event.time,
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.testTag(EventDetailsTestTags.EVENT_TIME),
-                ) // TODO we need some proper time to time-text
-                // formating
-                // (implement in repository)
-                Text(
-                    text = event.location.name,
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.testTag(EventDetailsTestTags.EVENT_LOCATION),
-                )
-              }
-            }
-            Row(verticalAlignment = Alignment.CenterVertically) {
-              Icon(
-                  imageVector = Icons.Default.AccessTime,
-                  contentDescription = "Time",
-                  tint = MaterialTheme.colorScheme.onSurfaceVariant,
-              )
-              Spacer(modifier = Modifier.width(8.dp))
-              Text(text = event.time, style = MaterialTheme.typography.bodyMedium)
-            }
-          }
-
-          // Description
-          Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(
-                text = "Description",
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-            )
-            Text(
-                text = event.description,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.testTag(EventDetailsTestTags.EVENT_DESCRIPTION),
-            )
-          }
-
-          Box(modifier = Modifier.fillMaxWidth().height(200.dp).clip(RoundedCornerShape(8.dp))) {
-            Map(
-                target = event.location,
-                enableControls = false,
-                locationPermissionRequest = {
-                  val isLocationGranted =
-                      ContextCompat.checkSelfPermission(
-                          context,
-                          Manifest.permission.ACCESS_FINE_LOCATION,
-                      ) == PackageManager.PERMISSION_GRANTED
-                  it(isLocationGranted)
-                },
-            )
-            // Spacer required to prevent clicks on the map itself
-            Spacer(
+            // Row containing: Date, Time, Location
+            // TODO-question: make this clickable to be displayed in Calender?
+            Row(
                 modifier =
-                    Modifier.matchParentSize()
-                        .clickable { onOpenMap(event.location) }
-                        .testTag(EventDetailsTestTags.VIEW_LOCATION_BUTTON),
-            )
-          }
+                    Modifier.fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .padding(12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+              Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.CalendarToday,
+                    contentDescription = "Date",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Column {
+                  Text(
+                      text = event.time,
+                      style = MaterialTheme.typography.bodyMedium,
+                      modifier = Modifier.testTag(EventDetailsTestTags.EVENT_TIME),
+                  ) // TODO we need some proper time to time-text
+                  // formating
+                  // (implement in repository)
+                  Text(
+                      text = event.location.name,
+                      style = MaterialTheme.typography.bodySmall,
+                      modifier = Modifier.testTag(EventDetailsTestTags.EVENT_LOCATION),
+                  )
+                }
+              }
+              Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.AccessTime,
+                    contentDescription = "Time",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = event.time, style = MaterialTheme.typography.bodyMedium)
+              }
+            }
 
-          // Enroll Button
-          Button(
-              onClick = onEnrollClick,
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .padding(top = 8.dp)
-                      .testTag(EventDetailsTestTags.ENROLL_BUTTON),
-              shape = RoundedCornerShape(6.dp),
-              colors =
-                  ButtonDefaults.buttonColors(
-                      containerColor = LifeRed,
-                      contentColor = Color.White,
-                  ),
-          ) {
-            Text("Enrol in event", style = MaterialTheme.typography.titleMedium)
+            // Description
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+              Text(
+                  text = "Description",
+                  style =
+                      MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+              )
+              Text(
+                  text = event.description,
+                  style = MaterialTheme.typography.bodyMedium,
+                  color = MaterialTheme.colorScheme.onSurface,
+                  modifier = Modifier.testTag(EventDetailsTestTags.EVENT_DESCRIPTION),
+              )
+            }
+
+            Box(modifier = Modifier.fillMaxWidth().height(200.dp).clip(RoundedCornerShape(8.dp))) {
+              Map(
+                  target = event.location,
+                  enableControls = false,
+                  locationPermissionRequest = {
+                    val isLocationGranted =
+                        ContextCompat.checkSelfPermission(
+                            context,
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                        ) == PackageManager.PERMISSION_GRANTED
+                    it(isLocationGranted)
+                  },
+              )
+              // Spacer required to prevent clicks on the map itself
+              Spacer(
+                  modifier =
+                      Modifier.matchParentSize()
+                          .clickable { onOpenMap(event.location) }
+                          .testTag(EventDetailsTestTags.VIEW_LOCATION_BUTTON),
+              )
+            }
+
+            // Enroll Button
+            Button(
+                onClick = onEnrollClick,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .padding(top = 8.dp)
+                        .testTag(EventDetailsTestTags.ENROLL_BUTTON),
+                shape = RoundedCornerShape(6.dp),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = LifeRed,
+                        contentColor = Color.White,
+                    ),
+            ) {
+              Text("Enrol in event", style = MaterialTheme.typography.titleMedium)
+            }
           }
         }
+        BackButton(
+            modifier = Modifier.align(Alignment.TopStart).testTag(EventDetailsTestTags.BACK_BUTTON),
+            onGoBack = onGoBack,
+        )
       }
 }
 


### PR DESCRIPTION
This PR allows the back button to overlay on the `EventDetailsScreen` and `AssociationDetailsScreen`.

Since these pages are scrollable, the back button would scroll with the page. This has been changed so the back button is always in the top left of the screen, and overlays with the page content. 

Page scrolled to the top
<img width="299" height="647" alt="image" src="https://github.com/user-attachments/assets/b1832d9f-2023-4667-b42d-e7797dbbf637" />

Page scrolled to the bottom
<img width="299" height="645" alt="image" src="https://github.com/user-attachments/assets/02924352-8261-43ca-a99c-5dab0c92c823" />
