### PR TITLE
Enable persistent offline caching

### DIFF
--- a/app/src/main/java/ch/epfllife/MainActivity.kt
+++ b/app/src/main/java/ch/epfllife/MainActivity.kt
@@ -43,6 +43,8 @@ import ch.epfllife.ui.navigation.Screen
 import ch.epfllife.ui.navigation.Tab
 import ch.epfllife.ui.settings.SettingsScreen
 import ch.epfllife.ui.theme.Theme
+import com.google.firebase.Firebase
+import com.google.firebase.database.database
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -54,6 +56,8 @@ class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
+    // Keep cached data across app restarts
+    Firebase.database.setPersistenceEnabled(true)
     setContent {
       ThemedApp(auth = Auth(CredentialManager.create(LocalContext.current)), db = Db.firestore)
     }
@@ -136,13 +140,15 @@ fun App(
                 onAssociationClick = { associationId ->
                   navigationActions.navigateToAssociationDetails(associationId)
                 },
-                db = db)
+                db = db,
+            )
           }
 
           composable(Screen.Calendar.route) {
             CalendarScreen(
                 onEventClick = { eventId -> navigationActions.navigateToEventDetails(eventId) },
-                db = db)
+                db = db,
+            )
           }
 
           composable(

--- a/app/src/main/java/ch/epfllife/ui/association/AssociationBrowserViewModel.kt
+++ b/app/src/main/java/ch/epfllife/ui/association/AssociationBrowserViewModel.kt
@@ -1,5 +1,6 @@
 package ch.epfllife.ui.association
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ch.epfllife.model.association.Association
@@ -26,20 +27,19 @@ class AssociationBrowserViewModel(private val db: Db) : ViewModel() {
   /** Fetches all associations from the repository and updates the [allAssociations] state. */
   fun refresh(signalFinished: () -> Unit = {}) {
     viewModelScope.launch {
-      val allAssociations =
-          try {
-            db.assocRepo.getAllAssociations()
-          } catch (_: Exception) {
-            emptyList()
-          }
-      _allAssociations.value = allAssociations
+      try {
+        val allAssociations = db.assocRepo.getAllAssociations()
+        _allAssociations.value = allAssociations
 
-      val currentUser = db.userRepo.getCurrentUser()
-      if (currentUser != null) {
-        _subscribedAssociations.value =
-            allAssociations.filter { currentUser.subscriptions.contains(it.id) }
-      } else {
-        _subscribedAssociations.value = emptyList()
+        val currentUser = db.userRepo.getCurrentUser()
+        if (currentUser != null) {
+          _subscribedAssociations.value =
+              allAssociations.filter { currentUser.subscriptions.contains(it.id) }
+        } else {
+          _subscribedAssociations.value = emptyList()
+        }
+      } catch (e: Exception) {
+        Log.e("AssociationBrowserViewModel", "Failed to refresh associations", e)
       }
 
       signalFinished()

--- a/app/src/main/java/ch/epfllife/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/ch/epfllife/ui/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package ch.epfllife.ui.home
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ch.epfllife.model.db.Db
@@ -21,24 +22,15 @@ class HomeViewModel(private val db: Db) : ViewModel() {
     viewModelScope.launch {
       try {
         _allEvents.value = db.eventRepo.getAllEvents()
-        val currentUser = db.userRepo.getCurrentUser()
-
-        if (currentUser != null) {
+        db.userRepo.getCurrentUser()?.let { currentUser ->
           val enrolledEventIds = currentUser.enrolledEvents
           _myEvents.value = _allEvents.value.filter { event -> enrolledEventIds.contains(event.id) }
-        } else {
-          _myEvents.value = emptyList()
         }
-      } catch (_: Exception) {
-        _allEvents.value = emptyList()
-        _myEvents.value = emptyList()
+      } catch (e: Exception) {
+        Log.e("HomeViewModel", "Failed to refresh events", e)
+        // Refresh failed, so we keep the previous state
       }
       signalFinished()
     }
-  }
-
-  // For testing purposes - allows setting myEvents directly
-  fun setMyEvents(events: List<Event>) {
-    _myEvents.value = events
   }
 }

--- a/app/src/main/java/ch/epfllife/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/ch/epfllife/ui/home/HomeViewModel.kt
@@ -22,9 +22,12 @@ class HomeViewModel(private val db: Db) : ViewModel() {
     viewModelScope.launch {
       try {
         _allEvents.value = db.eventRepo.getAllEvents()
-        db.userRepo.getCurrentUser()?.let { currentUser ->
-          val enrolledEventIds = currentUser.enrolledEvents
+        val user = db.userRepo.getCurrentUser()
+        if (user != null) {
+          val enrolledEventIds = user.enrolledEvents
           _myEvents.value = _allEvents.value.filter { event -> enrolledEventIds.contains(event.id) }
+        } else {
+          _myEvents.value = emptyList()
         }
       } catch (e: Exception) {
         Log.e("HomeViewModel", "Failed to refresh events", e)


### PR DESCRIPTION
### Overview

It turns out, we don't have to build our own SQLite database (I started to implement it and it is pretty ugly).
The firestore SDK already brings the functionality to [cache data](https://firebase.google.com/docs/firestore/manage-data/enable-offline#kotlin). This is also enabled by default.

However, the cache is only kept during the app runtime. I enabled [disk persistance](https://firebase.google.com/docs/database/android/offline-capabilities) as well now,
making it a true offline experience.

I also removed some cases where we reset the UI state to an empty list, in case an operation fails.
So in case going offline mid-request leads to problems, we don't reset the UI to show nothing.

### Notes

The offline mode is not perfect yet. This is in part due to using the `get` API instead of listeners.
When doing a get request, the SDK first tries to get the data from firestore. If that fails, it uses the local cache. This can mean a few seconds delay. When using listeners, this problem does not exist, because you just get an immediate update from the offline cache and then a delayed update from the online firestore (or not).
So we need to update from get to listener API in a follow up [PR](#243). Not sure if this will solve all problems, it seems like the viewmodel data presentation might also need some adjustment.


Part of #13
Resolves #268