### PR TITLE
Begin Implementation of Admin Screens

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/ui/admin/AddEditAssociationScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/admin/AddEditAssociationScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextInput
 import ch.epfllife.example_data.ExampleAssociations
+import ch.epfllife.model.association.Association
 import ch.epfllife.ui.theme.Theme
 import org.junit.Rule
 import org.junit.Test
@@ -16,9 +17,15 @@ class AddEditAssociationScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-  private fun setContent(viewModel: AddEditAssociationViewModel = AddEditAssociationViewModel()) {
+  private fun setContent(
+      viewModel: AddEditAssociationViewModel = AddEditAssociationViewModel(),
+      onSubmitSuccess: () -> Unit = {},
+  ) {
     composeTestRule.setContent {
-      Theme { AddEditAssociationScreen(viewModel = viewModel, onBack = {}, onSubmitSuccess = {}) }
+      Theme {
+        AddEditAssociationScreen(
+            viewModel = viewModel, onBack = {}, onSubmitSuccess = onSubmitSuccess)
+      }
     }
   }
 
@@ -28,7 +35,7 @@ class AddEditAssociationScreenTest {
 
     composeTestRule.onNodeWithTag(AddEditAssociationTestTags.SUBMIT_BUTTON).assertIsNotEnabled()
 
-    fillMandatoryFields("New Association", "Short description", "Detailed about section")
+    fillMandatoryFields(ExampleAssociations.association4)
 
     composeTestRule.onNodeWithTag(AddEditAssociationTestTags.SUBMIT_BUTTON).assertIsEnabled()
   }
@@ -51,7 +58,11 @@ class AddEditAssociationScreenTest {
     }
   }
 
-  private fun fillMandatoryFields(name: String, description: String, about: String) {
+  private fun fillMandatoryFields(association: Association) {
+    val name = association.name
+    val description = association.description
+    val about = association.about ?: "About ${association.name}"
+
     composeTestRule.onNodeWithTag(AddEditAssociationTestTags.NAME_FIELD).performTextInput(name)
     composeTestRule
         .onNodeWithTag(AddEditAssociationTestTags.DESCRIPTION_FIELD)

--- a/app/src/androidTest/java/ch/epfllife/ui/admin/AddEditAssociationScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/admin/AddEditAssociationScreenTest.kt
@@ -1,0 +1,61 @@
+package ch.epfllife.ui.admin
+
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTextInput
+import ch.epfllife.example_data.ExampleAssociations
+import ch.epfllife.ui.theme.Theme
+import org.junit.Rule
+import org.junit.Test
+
+class AddEditAssociationScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private fun setContent(viewModel: AddEditAssociationViewModel = AddEditAssociationViewModel()) {
+    composeTestRule.setContent {
+      Theme { AddEditAssociationScreen(viewModel = viewModel, onBack = {}, onSubmitSuccess = {}) }
+    }
+  }
+
+  @Test
+  fun submitButtonRequiresMandatoryFields() {
+    setContent()
+
+    composeTestRule.onNodeWithTag(AddEditAssociationTestTags.SUBMIT_BUTTON).assertIsNotEnabled()
+
+    fillMandatoryFields("New Association", "Short description", "Detailed about section")
+
+    composeTestRule.onNodeWithTag(AddEditAssociationTestTags.SUBMIT_BUTTON).assertIsEnabled()
+  }
+
+  @Test
+  fun editingExistingAssociationPrefillsForm() {
+    val association = ExampleAssociations.association1
+    setContent(AddEditAssociationViewModel(existingAssociation = association))
+
+    composeTestRule
+        .onNodeWithTag(AddEditAssociationTestTags.NAME_FIELD)
+        .assert(hasText(association.name, substring = false))
+    composeTestRule
+        .onNodeWithTag(AddEditAssociationTestTags.DESCRIPTION_FIELD)
+        .assert(hasText(association.description, substring = false))
+    association.about?.let {
+      composeTestRule
+          .onNodeWithTag(AddEditAssociationTestTags.ABOUT_FIELD)
+          .assert(hasText(it, substring = false))
+    }
+  }
+
+  private fun fillMandatoryFields(name: String, description: String, about: String) {
+    composeTestRule.onNodeWithTag(AddEditAssociationTestTags.NAME_FIELD).performTextInput(name)
+    composeTestRule
+        .onNodeWithTag(AddEditAssociationTestTags.DESCRIPTION_FIELD)
+        .performTextInput(description)
+    composeTestRule.onNodeWithTag(AddEditAssociationTestTags.ABOUT_FIELD).performTextInput(about)
+  }
+}

--- a/app/src/androidTest/java/ch/epfllife/ui/admin/SelectAssociationScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/admin/SelectAssociationScreenTest.kt
@@ -1,7 +1,6 @@
 package ch.epfllife.ui.admin
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -11,6 +10,7 @@ import ch.epfllife.model.association.AssociationRepository
 import ch.epfllife.model.db.Db
 import ch.epfllife.model.event.Event
 import ch.epfllife.ui.theme.Theme
+import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
@@ -32,14 +32,7 @@ class SelectAssociationScreenTest {
       }
     }
 
-    composeTestRule.waitUntil(5_000) {
-      composeTestRule
-          .onAllNodes(
-              hasTestTag(
-                  SelectAssociationTestTags.associationCard(ExampleAssociations.association1.id)))
-          .fetchSemanticsNodes()
-          .isNotEmpty()
-    }
+    composeTestRule.waitForIdle()
 
     composeTestRule
         .onNodeWithTag(
@@ -67,21 +60,13 @@ class SelectAssociationScreenTest {
       }
     }
 
-    composeTestRule.waitUntil(5_000) {
-      composeTestRule
-          .onAllNodes(
-              hasTestTag(
-                  SelectAssociationTestTags.associationCard(ExampleAssociations.association2.id)))
-          .fetchSemanticsNodes()
-          .isNotEmpty()
-    }
+    composeTestRule.waitForIdle()
 
     composeTestRule
         .onNodeWithTag(
             SelectAssociationTestTags.associationCard(ExampleAssociations.association2.id))
         .performClick()
 
-    composeTestRule.waitUntil(5_000) { selectedAssociation != null }
     assertNotNull(selectedAssociation)
     assertEquals(ExampleAssociations.association2.id, selectedAssociation?.id)
   }
@@ -107,16 +92,11 @@ class SelectAssociationScreenTest {
       }
     }
 
-    composeTestRule.waitUntil(5_000) {
-      composeTestRule
-          .onAllNodes(hasTestTag(SelectAssociationTestTags.ADD_NEW_BUTTON))
-          .fetchSemanticsNodes()
-          .isNotEmpty()
-    }
+    composeTestRule.waitForIdle()
 
     composeTestRule.onNodeWithTag(SelectAssociationTestTags.ADD_NEW_BUTTON).performClick()
 
-    composeTestRule.waitUntil(5_000) { addNewClicked }
+    Assert.assertTrue(addNewClicked)
   }
 }
 

--- a/app/src/androidTest/java/ch/epfllife/ui/admin/SelectAssociationScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/admin/SelectAssociationScreenTest.kt
@@ -1,0 +1,120 @@
+package ch.epfllife.ui.admin
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import ch.epfllife.example_data.ExampleAssociations
+import ch.epfllife.model.association.Association
+import ch.epfllife.model.association.AssociationRepository
+import ch.epfllife.model.db.Db
+import ch.epfllife.model.event.Event
+import ch.epfllife.ui.theme.Theme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+
+class SelectAssociationScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun displaysAssociationsFromRepository() {
+    val db =
+        fakeDbWithAssociations(ExampleAssociations.association1, ExampleAssociations.association2)
+
+    composeTestRule.setContent {
+      Theme {
+        SelectAssociationScreen(
+            db = db, onGoBack = {}, onAssociationSelected = {}, onAddNewAssociation = {})
+      }
+    }
+
+    composeTestRule.waitUntil(5_000) {
+      composeTestRule
+          .onAllNodes(
+              hasTestTag(
+                  SelectAssociationTestTags.associationCard(ExampleAssociations.association1.id)))
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
+
+    composeTestRule
+        .onNodeWithTag(
+            SelectAssociationTestTags.associationCard(ExampleAssociations.association1.id))
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(
+            SelectAssociationTestTags.associationCard(ExampleAssociations.association2.id))
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun selectingAssociationCallsBackWithCorrectData() {
+    val db =
+        fakeDbWithAssociations(ExampleAssociations.association1, ExampleAssociations.association2)
+    var selectedAssociation: Association? = null
+
+    composeTestRule.setContent {
+      Theme {
+        SelectAssociationScreen(
+            db = db,
+            onGoBack = {},
+            onAssociationSelected = { selectedAssociation = it },
+            onAddNewAssociation = {})
+      }
+    }
+
+    composeTestRule.waitUntil(5_000) {
+      composeTestRule
+          .onAllNodes(
+              hasTestTag(
+                  SelectAssociationTestTags.associationCard(ExampleAssociations.association2.id)))
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
+
+    composeTestRule
+        .onNodeWithTag(
+            SelectAssociationTestTags.associationCard(ExampleAssociations.association2.id))
+        .performClick()
+
+    composeTestRule.waitUntil(5_000) { selectedAssociation != null }
+    assertNotNull(selectedAssociation)
+    assertEquals(ExampleAssociations.association2.id, selectedAssociation?.id)
+  }
+
+  private fun fakeDbWithAssociations(vararg associations: Association): Db {
+    val baseDb = Db.freshLocal()
+    val fakeRepo = FakeAssociationRepository(associations.toList())
+    return baseDb.copy(assocRepo = fakeRepo)
+  }
+}
+
+private class FakeAssociationRepository(
+    private val associations: List<Association>,
+) : AssociationRepository {
+
+  override suspend fun getAllAssociations(): List<Association> = associations
+
+  override suspend fun getAssociation(associationId: String): Association? =
+      associations.firstOrNull { it.id == associationId }
+
+  override fun getNewUid(): String = "fake-id"
+
+  override suspend fun createAssociation(association: Association): Result<Unit> =
+      Result.failure(UnsupportedOperationException("Not needed"))
+
+  override suspend fun deleteAssociation(associationId: String): Result<Unit> =
+      Result.failure(UnsupportedOperationException("Not needed"))
+
+  override suspend fun updateAssociation(
+      associationId: String,
+      newAssociation: Association,
+  ): Result<Unit> = Result.failure(UnsupportedOperationException("Not needed"))
+
+  override suspend fun getEventsForAssociation(associationId: String): Result<List<Event>> =
+      Result.success(emptyList())
+}

--- a/app/src/androidTest/java/ch/epfllife/ui/admin/SelectAssociationScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/admin/SelectAssociationScreenTest.kt
@@ -91,6 +91,33 @@ class SelectAssociationScreenTest {
     val fakeRepo = FakeAssociationRepository(associations.toList())
     return baseDb.copy(assocRepo = fakeRepo)
   }
+
+  @Test
+  fun addNewAssociationButtonInvokesCallback() {
+    val db = fakeDbWithAssociations(ExampleAssociations.association1)
+    var addNewClicked = false
+
+    composeTestRule.setContent {
+      Theme {
+        SelectAssociationScreen(
+            db = db,
+            onGoBack = {},
+            onAssociationSelected = {},
+            onAddNewAssociation = { addNewClicked = true })
+      }
+    }
+
+    composeTestRule.waitUntil(5_000) {
+      composeTestRule
+          .onAllNodes(hasTestTag(SelectAssociationTestTags.ADD_NEW_BUTTON))
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
+
+    composeTestRule.onNodeWithTag(SelectAssociationTestTags.ADD_NEW_BUTTON).performClick()
+
+    composeTestRule.waitUntil(5_000) { addNewClicked }
+  }
 }
 
 private class FakeAssociationRepository(

--- a/app/src/androidTest/java/ch/epfllife/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/settings/SettingsScreenTest.kt
@@ -74,7 +74,7 @@ class SettingsScreenTest {
           onAddNewAssociationClick = {})
     }
     composeTestRule.onNodeWithTag(SettingsScreenTestTags.SIGN_OUT_BUTTON).performClick()
-      composeTestRule.waitForIdle()
+    composeTestRule.waitForIdle()
     Assert.assertNull(Firebase.auth.currentUser)
     Assert.assertEquals(
         composeTestRule.activity.getString(R.string.signout_successful),
@@ -95,7 +95,7 @@ class SettingsScreenTest {
     }
 
     composeTestRule.onNodeWithTag(SettingsScreenTestTags.SELECT_ASSOCIATION_BUTTON).performClick()
-      Assert.assertTrue(clicked)
+    Assert.assertTrue(clicked)
   }
 
   @Test
@@ -120,7 +120,7 @@ class SettingsScreenTest {
     composeTestRule.onNodeWithTag(SettingsScreenTestTags.MANAGE_ASSOCIATION_BUTTON).performClick()
     composeTestRule.onNodeWithTag(SettingsScreenTestTags.MANAGE_EVENTS_BUTTON).performClick()
 
-      Assert.assertEquals(associationId, manageClickedId)
-      Assert.assertEquals(associationId, manageEventsClickedId)
-    }
+    Assert.assertEquals(associationId, manageClickedId)
+    Assert.assertEquals(associationId, manageEventsClickedId)
   }
+}

--- a/app/src/androidTest/java/ch/epfllife/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/settings/SettingsScreenTest.kt
@@ -80,4 +80,48 @@ class SettingsScreenTest {
         composeTestRule.activity.getString(R.string.signout_successful),
         fakeToastHelper.lastMessage)
   }
+
+  @Test
+  fun selectAssociationButtonInvokesCallback() {
+    var clicked = false
+    composeTestRule.setContent {
+      SettingsScreen(
+          auth = auth,
+          onSignedOut = {},
+          onSelectAssociationClick = { clicked = true },
+          onManageAssociationClick = {},
+          onManageAssociationEventsClick = {},
+          onAddNewAssociationClick = {})
+    }
+
+    composeTestRule.onNodeWithTag(SettingsScreenTestTags.SELECT_ASSOCIATION_BUTTON).performClick()
+    composeTestRule.waitUntil(5_000) { clicked }
+  }
+
+  @Test
+  fun manageButtonsVisibleAndClickableWhenAssociationSelected() {
+    val associationId = "asso-sat"
+    val associationName = "Satellite"
+    var manageClickedId: String? = null
+    var manageEventsClickedId: String? = null
+
+    composeTestRule.setContent {
+      SettingsScreen(
+          auth = auth,
+          onSignedOut = {},
+          selectedAssociationId = associationId,
+          selectedAssociationName = associationName,
+          onSelectAssociationClick = {},
+          onManageAssociationClick = { manageClickedId = it },
+          onManageAssociationEventsClick = { manageEventsClickedId = it },
+          onAddNewAssociationClick = {})
+    }
+
+    composeTestRule.onNodeWithTag(SettingsScreenTestTags.MANAGE_ASSOCIATION_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(SettingsScreenTestTags.MANAGE_EVENTS_BUTTON).performClick()
+
+    composeTestRule.waitUntil(5_000) {
+      manageClickedId == associationId && manageEventsClickedId == associationId
+    }
+  }
 }

--- a/app/src/androidTest/java/ch/epfllife/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/settings/SettingsScreenTest.kt
@@ -74,7 +74,7 @@ class SettingsScreenTest {
           onAddNewAssociationClick = {})
     }
     composeTestRule.onNodeWithTag(SettingsScreenTestTags.SIGN_OUT_BUTTON).performClick()
-    composeTestRule.waitUntil(5000) { clicked }
+      composeTestRule.waitForIdle()
     Assert.assertNull(Firebase.auth.currentUser)
     Assert.assertEquals(
         composeTestRule.activity.getString(R.string.signout_successful),
@@ -95,7 +95,7 @@ class SettingsScreenTest {
     }
 
     composeTestRule.onNodeWithTag(SettingsScreenTestTags.SELECT_ASSOCIATION_BUTTON).performClick()
-    composeTestRule.waitUntil(5_000) { clicked }
+      Assert.assertTrue(clicked)
   }
 
   @Test
@@ -120,8 +120,7 @@ class SettingsScreenTest {
     composeTestRule.onNodeWithTag(SettingsScreenTestTags.MANAGE_ASSOCIATION_BUTTON).performClick()
     composeTestRule.onNodeWithTag(SettingsScreenTestTags.MANAGE_EVENTS_BUTTON).performClick()
 
-    composeTestRule.waitUntil(5_000) {
-      manageClickedId == associationId && manageEventsClickedId == associationId
+      Assert.assertEquals(associationId, manageClickedId)
+      Assert.assertEquals(associationId, manageEventsClickedId)
     }
   }
-}

--- a/app/src/androidTest/java/ch/epfllife/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/settings/SettingsScreenTest.kt
@@ -43,7 +43,15 @@ class SettingsScreenTest {
 
   @Test
   fun contentIsDisplayed() {
-    composeTestRule.setContent { SettingsScreen(auth = auth, onSignedOut = {}) }
+    composeTestRule.setContent {
+      SettingsScreen(
+          auth = auth,
+          onSignedOut = {},
+          onSelectAssociationClick = {},
+          onManageAssociationClick = {},
+          onManageAssociationEventsClick = {},
+          onAddNewAssociationClick = {})
+    }
     listOf(
             NavigationTestTags.SETTINGS_SCREEN,
             SettingsScreenTestTags.SIGN_OUT_BUTTON,
@@ -56,7 +64,14 @@ class SettingsScreenTest {
     Assert.assertNotNull(Firebase.auth.currentUser)
     var clicked = false
     composeTestRule.setContent {
-      SettingsScreen(auth = auth, onSignedOut = { clicked = true }, toastHelper = fakeToastHelper)
+      SettingsScreen(
+          auth = auth,
+          onSignedOut = { clicked = true },
+          toastHelper = fakeToastHelper,
+          onSelectAssociationClick = {},
+          onManageAssociationClick = {},
+          onManageAssociationEventsClick = {},
+          onAddNewAssociationClick = {})
     }
     composeTestRule.onNodeWithTag(SettingsScreenTestTags.SIGN_OUT_BUTTON).performClick()
     composeTestRule.waitUntil(5000) { clicked }

--- a/app/src/main/java/ch/epfllife/MainActivity.kt
+++ b/app/src/main/java/ch/epfllife/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.navigation.navArgument
 import ch.epfllife.model.authentication.Auth
 import ch.epfllife.model.db.Db
 import ch.epfllife.model.map.Location
+import ch.epfllife.ui.admin.SelectAssociationScreen
 import ch.epfllife.ui.association.AssociationBrowser
 import ch.epfllife.ui.association.AssociationDetailsScreen
 import ch.epfllife.ui.authentication.SignInScreen
@@ -183,7 +184,22 @@ fun App(
             SettingsScreen(
                 auth = auth,
                 onSignedOut = { navigationActions.navigateTo(Screen.SignIn) },
-            )
+                onSelectAssociationClick = {
+                  navigationActions.navigateTo(Screen.SelectAssociation)
+                })
+          }
+
+          composable(Screen.SelectAssociation.route) {
+            SelectAssociationScreen(
+                db = db,
+                onGoBack = { navController.popBackStack() },
+                onAssociationSelected = { associationId ->
+                  // TODO: Store selected association
+                  navController.popBackStack()
+                },
+                onAddNewAssociation = {
+                  // TODO: Navigate to future CreateAssociationScreen
+                })
           }
         }
       }

--- a/app/src/main/java/ch/epfllife/MainActivity.kt
+++ b/app/src/main/java/ch/epfllife/MainActivity.kt
@@ -226,6 +226,7 @@ fun App(
                 val association: Association? = null // replace with db call later
                 AddEditAssociationScreen(
                     viewModel = AddEditAssociationViewModel(association),
+                    onBack = { navController.popBackStack() },
                     onSubmitSuccess = { navController.popBackStack() })
               }
         }

--- a/app/src/main/java/ch/epfllife/MainActivity.kt
+++ b/app/src/main/java/ch/epfllife/MainActivity.kt
@@ -20,9 +20,12 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import ch.epfllife.model.association.Association
 import ch.epfllife.model.authentication.Auth
 import ch.epfllife.model.db.Db
 import ch.epfllife.model.map.Location
+import ch.epfllife.ui.admin.AddEditAssociationScreen
+import ch.epfllife.ui.admin.AddEditAssociationViewModel
 import ch.epfllife.ui.admin.SelectAssociationScreen
 import ch.epfllife.ui.association.AssociationBrowser
 import ch.epfllife.ui.association.AssociationDetailsScreen
@@ -186,7 +189,14 @@ fun App(
                 onSignedOut = { navigationActions.navigateTo(Screen.SignIn) },
                 onSelectAssociationClick = {
                   navigationActions.navigateTo(Screen.SelectAssociation)
-                })
+                },
+                onManageAssociationClick = { associationId ->
+                  navigationActions.navigateToAddEditAssociation(associationId)
+                },
+                onManageAssociationEventsClick = { associationId ->
+                  // placeholder, can navigate to manage events later
+                },
+                onAddNewAssociationClick = { navigationActions.navigateToAddEditAssociation() })
           }
 
           composable(Screen.SelectAssociation.route) {
@@ -194,13 +204,30 @@ fun App(
                 db = db,
                 onGoBack = { navController.popBackStack() },
                 onAssociationSelected = { associationId ->
-                  // TODO: Store selected association
                   navController.popBackStack()
+                  navigationActions.navigateTo(Screen.Settings)
                 },
-                onAddNewAssociation = {
-                  // TODO: Navigate to future CreateAssociationScreen
-                })
+                onAddNewAssociation = { navigationActions.navigateToAddEditAssociation() })
           }
+
+          composable(
+              route = Screen.AddEditAssociation.route,
+              arguments =
+                  listOf(
+                      navArgument(Screen.AddEditAssociation.ASSOCIATION_ID_ARG) {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                      })) { backStackEntry ->
+                val associationId =
+                    backStackEntry.arguments?.getString(
+                        Screen.AddEditAssociation.ASSOCIATION_ID_ARG)
+                // For now, placeholder
+                val association: Association? = null // replace with db call later
+                AddEditAssociationScreen(
+                    viewModel = AddEditAssociationViewModel(association),
+                    onSubmitSuccess = { navController.popBackStack() })
+              }
         }
       }
 }

--- a/app/src/main/java/ch/epfllife/MainActivity.kt
+++ b/app/src/main/java/ch/epfllife/MainActivity.kt
@@ -206,7 +206,7 @@ fun App(
                   navigationActions.navigateToAddEditAssociation(associationId)
                 },
                 onManageAssociationEventsClick = { associationId ->
-                  // placeholder, can navigate to manage events later
+                  // TODO: placeholder, can navigate to manage events later
                 },
                 selectedAssociationId = selectedAssociationId,
                 selectedAssociationName = selectedAssociationName,
@@ -241,8 +241,8 @@ fun App(
                 val associationId =
                     backStackEntry.arguments?.getString(
                         Screen.AddEditAssociation.ASSOCIATION_ID_ARG)
-                // For now, placeholder
-                val association: Association? = null // replace with db call later
+                // TODO: For now, placeholder
+                val association: Association? = null // TODO: replace with db call later
                 AddEditAssociationScreen(
                     viewModel = AddEditAssociationViewModel(association),
                     onBack = { navController.popBackStack() },

--- a/app/src/main/java/ch/epfllife/MainActivity.kt
+++ b/app/src/main/java/ch/epfllife/MainActivity.kt
@@ -205,7 +205,7 @@ fun App(
                 onManageAssociationClick = { associationId ->
                   navigationActions.navigateToAddEditAssociation(associationId)
                 },
-                onManageAssociationEventsClick = { associationId ->
+                onManageAssociationEventsClick = { _ -> // use AssociationID
                   // TODO: placeholder, can navigate to manage events later
                 },
                 selectedAssociationId = selectedAssociationId,

--- a/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationScreen.kt
@@ -55,14 +55,14 @@ fun AddEditAssociationScreen(
               text = stringResource(R.string.add_new_association),
               style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
               modifier = Modifier.testTag(AddEditAssociationTestTags.HEADER))
-          HorizontalDivider(color = Color.Black)
+          HorizontalDivider(color = MaterialTheme.colorScheme.onSurfaceVariant)
 
           // --- General Info ---
           Text(
               text = stringResource(R.string.general_info),
-              color = Color.Gray,
+              color = MaterialTheme.colorScheme.outline,
               style = MaterialTheme.typography.titleSmall)
-          HorizontalDivider(color = Color.Gray)
+          HorizontalDivider(color = MaterialTheme.colorScheme.outline)
 
           OutlinedTextField(
               value = formState.name,
@@ -89,9 +89,9 @@ fun AddEditAssociationScreen(
           // --- Social Pages ---
           Text(
               text = stringResource(R.string.social_pages_title),
-              color = Color.Gray,
+              color = MaterialTheme.colorScheme.outline,
               style = MaterialTheme.typography.titleSmall)
-          HorizontalDivider(color = Color.Gray)
+          HorizontalDivider(color = MaterialTheme.colorScheme.outline)
 
           formState.socialMedia.forEach { sm ->
             Row(
@@ -126,9 +126,9 @@ fun AddEditAssociationScreen(
           // --- Upload Images (URLs) ---
           Text(
               text = stringResource(R.string.upload_images),
-              color = Color.Gray,
+              color = MaterialTheme.colorScheme.outline,
               style = MaterialTheme.typography.titleSmall)
-          HorizontalDivider(color = Color.Gray)
+          HorizontalDivider(color = MaterialTheme.colorScheme.outline)
 
           OutlinedTextField(
               value = formState.logoUrl,

--- a/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationScreen.kt
@@ -2,6 +2,7 @@ package ch.epfllife.ui.admin
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -9,105 +10,146 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.epfllife.R
 import ch.epfllife.ui.association.SocialIcons
+import ch.epfllife.ui.composables.BackButton
 import ch.epfllife.ui.theme.LifeRed
 
 @Composable
 fun AddEditAssociationScreen(
     viewModel: AddEditAssociationViewModel = viewModel(),
+    onBack: () -> Unit,
     onSubmitSuccess: () -> Unit
 ) {
   val scrollState = rememberScrollState()
   val formState = viewModel.formState
 
-  Column(
-      modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(16.dp),
-      verticalArrangement = Arrangement.spacedBy(16.dp)) {
+  Box(modifier = Modifier.fillMaxSize()) {
 
-        // --- General Info ---
-        Text("General Info", color = Color.Gray, style = MaterialTheme.typography.titleSmall)
-        HorizontalDivider(color = Color.Gray)
+    // Scrollable form content
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(
+                    top = 72.dp,
+                    start = 16.dp,
+                    end = 16.dp,
+                    bottom = 16.dp), // leave space for back arrow
+        verticalArrangement = Arrangement.spacedBy(16.dp)) {
+          // --- Header ---
+          Text(
+              text = stringResource(R.string.add_new_association),
+              style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold))
+          HorizontalDivider(color = Color.Black)
 
-        OutlinedTextField(
-            value = formState.name,
-            onValueChange = { viewModel.updateName(it) },
-            label = { Text("Association Name*") },
-            modifier = Modifier.fillMaxWidth())
+          // --- General Info ---
+          Text(
+              text = stringResource(R.string.general_info),
+              color = Color.Gray,
+              style = MaterialTheme.typography.titleSmall)
+          HorizontalDivider(color = Color.Gray)
 
-        OutlinedTextField(
-            value = formState.description,
-            onValueChange = { viewModel.updateDescription(it) },
-            label = { Text("Short Description*") },
-            modifier = Modifier.fillMaxWidth())
+          OutlinedTextField(
+              value = formState.name,
+              onValueChange = { viewModel.updateName(it) },
+              label = { Text(stringResource(R.string.association_name_required)) },
+              modifier = Modifier.fillMaxWidth())
 
-        OutlinedTextField(
-            value = formState.about,
-            onValueChange = { viewModel.updateAbout(it) },
-            label = { Text("About the Association*") },
-            modifier = Modifier.fillMaxWidth().height(120.dp))
+          OutlinedTextField(
+              value = formState.description,
+              onValueChange = { viewModel.updateDescription(it) },
+              label = { Text(stringResource(R.string.short_description_required)) },
+              modifier = Modifier.fillMaxWidth())
 
-        // --- Social Pages ---
-        Text("Social Pages", color = Color.Gray, style = MaterialTheme.typography.titleSmall)
-        HorizontalDivider(color = Color.Gray)
+          OutlinedTextField(
+              value = formState.about,
+              onValueChange = { viewModel.updateAbout(it) },
+              label = { Text(stringResource(R.string.about_association_required)) },
+              modifier = Modifier.fillMaxWidth().height(120.dp))
 
-        formState.socialMedia.forEach { sm ->
-          Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-            Checkbox(
-                checked = sm.enabled,
-                onCheckedChange = { viewModel.updateSocialMedia(sm.platform, it) },
-                modifier = Modifier.padding(0.dp))
+          // --- Social Pages ---
+          Text(
+              text = stringResource(R.string.social_pages_title),
+              color = Color.Gray,
+              style = MaterialTheme.typography.titleSmall)
+          HorizontalDivider(color = Color.Gray)
 
-            Spacer(modifier = Modifier.width(8.dp))
+          formState.socialMedia.forEach { sm ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()) {
+                  Checkbox(
+                      checked = sm.enabled,
+                      onCheckedChange = { viewModel.updateSocialMedia(sm.platform, it) },
+                      modifier = Modifier.padding(0.dp))
 
-            Icon(
-                painter =
-                    painterResource(SocialIcons.getIcon(sm.platform) ?: R.drawable.ic_default),
-                contentDescription = sm.platform,
-                tint = Color.Unspecified,
-                modifier = Modifier.size(32.dp))
+                  Spacer(modifier = Modifier.width(8.dp))
 
-            Spacer(modifier = Modifier.width(16.dp))
+                  Icon(
+                      painter =
+                          painterResource(
+                              SocialIcons.getIcon(sm.platform) ?: R.drawable.ic_default),
+                      contentDescription = sm.platform,
+                      tint = Color.Unspecified,
+                      modifier = Modifier.size(32.dp))
 
-            OutlinedTextField(
-                value = sm.link,
-                onValueChange = { viewModel.updateSocialMediaLink(sm.platform, it) },
-                label = { Text("Link") },
-                enabled = sm.enabled,
-                modifier = Modifier.weight(1f))
+                  Spacer(modifier = Modifier.width(16.dp))
+
+                  OutlinedTextField(
+                      value = sm.link,
+                      onValueChange = { viewModel.updateSocialMediaLink(sm.platform, it) },
+                      label = { Text(stringResource(R.string.website_description)) },
+                      enabled = sm.enabled,
+                      modifier = Modifier.weight(1f))
+                }
           }
+
+          // --- Upload Images (URLs) ---
+          Text(
+              text = stringResource(R.string.upload_images),
+              color = Color.Gray,
+              style = MaterialTheme.typography.titleSmall)
+          HorizontalDivider(color = Color.Gray)
+
+          OutlinedTextField(
+              value = formState.logoUrl,
+              onValueChange = { viewModel.updateLogoUrl(it) },
+              label = { Text(stringResource(R.string.logo_url)) },
+              modifier = Modifier.fillMaxWidth())
+
+          OutlinedTextField(
+              value = formState.bannerUrl,
+              onValueChange = { viewModel.updateBannerUrl(it) },
+              label = { Text(stringResource(R.string.banner_url)) },
+              modifier = Modifier.fillMaxWidth())
+
+          Spacer(Modifier.height(24.dp))
+
+          // --- Submit Button ---
+          Button(
+              modifier = Modifier.fillMaxWidth().height(50.dp),
+              onClick = { viewModel.submit(onSubmitSuccess) },
+              shape = RoundedCornerShape(6.dp),
+              colors =
+                  ButtonDefaults.buttonColors(containerColor = LifeRed, contentColor = Color.White),
+              enabled = viewModel.isFormValid()) {
+                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                  Text(
+                      text = stringResource(R.string.submit),
+                      style =
+                          MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold))
+                }
+              }
+
+          Spacer(Modifier.height(24.dp))
         }
 
-        // --- Upload Images (URLs) ---
-        Text("Upload Images", color = Color.Gray, style = MaterialTheme.typography.titleSmall)
-        HorizontalDivider(color = Color.Gray)
-
-        OutlinedTextField(
-            value = formState.logoUrl,
-            onValueChange = { viewModel.updateLogoUrl(it) },
-            label = { Text("Logo URL") },
-            modifier = Modifier.fillMaxWidth())
-
-        OutlinedTextField(
-            value = formState.bannerUrl,
-            onValueChange = { viewModel.updateBannerUrl(it) },
-            label = { Text("Banner URL") },
-            modifier = Modifier.fillMaxWidth())
-
-        Spacer(Modifier.height(24.dp))
-
-        // --- Submit Button ---
-        Button(
-            onClick = { viewModel.submit(onSubmitSuccess) },
-            enabled = viewModel.isFormValid(),
-            colors =
-                ButtonDefaults.buttonColors(containerColor = LifeRed, contentColor = Color.White),
-            modifier = Modifier.fillMaxWidth().height(50.dp)) {
-              Text("Submit", style = MaterialTheme.typography.bodyLarge)
-            }
-
-        Spacer(Modifier.height(24.dp))
-      }
+    // --- Back Button Overlay ---
+    BackButton(onGoBack = onBack)
+  }
 }

--- a/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -18,6 +19,14 @@ import ch.epfllife.R
 import ch.epfllife.ui.association.SocialIcons
 import ch.epfllife.ui.composables.BackButton
 import ch.epfllife.ui.theme.LifeRed
+
+object AddEditAssociationTestTags {
+  const val HEADER = "AddEditAssociation_Header"
+  const val NAME_FIELD = "AddEditAssociation_NameField"
+  const val DESCRIPTION_FIELD = "AddEditAssociation_DescriptionField"
+  const val ABOUT_FIELD = "AddEditAssociation_AboutField"
+  const val SUBMIT_BUTTON = "AddEditAssociation_SubmitButton"
+}
 
 @Composable
 fun AddEditAssociationScreen(
@@ -44,7 +53,8 @@ fun AddEditAssociationScreen(
           // --- Header ---
           Text(
               text = stringResource(R.string.add_new_association),
-              style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold))
+              style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+              modifier = Modifier.testTag(AddEditAssociationTestTags.HEADER))
           HorizontalDivider(color = Color.Black)
 
           // --- General Info ---
@@ -58,19 +68,23 @@ fun AddEditAssociationScreen(
               value = formState.name,
               onValueChange = { viewModel.updateName(it) },
               label = { Text(stringResource(R.string.association_name_required)) },
-              modifier = Modifier.fillMaxWidth())
+              modifier = Modifier.fillMaxWidth().testTag(AddEditAssociationTestTags.NAME_FIELD))
 
           OutlinedTextField(
               value = formState.description,
               onValueChange = { viewModel.updateDescription(it) },
               label = { Text(stringResource(R.string.short_description_required)) },
-              modifier = Modifier.fillMaxWidth())
+              modifier =
+                  Modifier.fillMaxWidth().testTag(AddEditAssociationTestTags.DESCRIPTION_FIELD))
 
           OutlinedTextField(
               value = formState.about,
               onValueChange = { viewModel.updateAbout(it) },
               label = { Text(stringResource(R.string.about_association_required)) },
-              modifier = Modifier.fillMaxWidth().height(120.dp))
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .height(120.dp)
+                      .testTag(AddEditAssociationTestTags.ABOUT_FIELD))
 
           // --- Social Pages ---
           Text(
@@ -132,7 +146,10 @@ fun AddEditAssociationScreen(
 
           // --- Submit Button ---
           Button(
-              modifier = Modifier.fillMaxWidth().height(50.dp),
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .height(50.dp)
+                      .testTag(AddEditAssociationTestTags.SUBMIT_BUTTON),
               onClick = { viewModel.submit(onSubmitSuccess) },
               shape = RoundedCornerShape(6.dp),
               colors =

--- a/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationScreen.kt
@@ -1,0 +1,113 @@
+package ch.epfllife.ui.admin
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.epfllife.R
+import ch.epfllife.ui.association.SocialIcons
+import ch.epfllife.ui.theme.LifeRed
+
+@Composable
+fun AddEditAssociationScreen(
+    viewModel: AddEditAssociationViewModel = viewModel(),
+    onSubmitSuccess: () -> Unit
+) {
+  val scrollState = rememberScrollState()
+  val formState = viewModel.formState
+
+  Column(
+      modifier = Modifier.fillMaxSize().verticalScroll(scrollState).padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(16.dp)) {
+
+        // --- General Info ---
+        Text("General Info", color = Color.Gray, style = MaterialTheme.typography.titleSmall)
+        HorizontalDivider(color = Color.Gray)
+
+        OutlinedTextField(
+            value = formState.name,
+            onValueChange = { viewModel.updateName(it) },
+            label = { Text("Association Name*") },
+            modifier = Modifier.fillMaxWidth())
+
+        OutlinedTextField(
+            value = formState.description,
+            onValueChange = { viewModel.updateDescription(it) },
+            label = { Text("Short Description*") },
+            modifier = Modifier.fillMaxWidth())
+
+        OutlinedTextField(
+            value = formState.about,
+            onValueChange = { viewModel.updateAbout(it) },
+            label = { Text("About the Association*") },
+            modifier = Modifier.fillMaxWidth().height(120.dp))
+
+        // --- Social Pages ---
+        Text("Social Pages", color = Color.Gray, style = MaterialTheme.typography.titleSmall)
+        HorizontalDivider(color = Color.Gray)
+
+        formState.socialMedia.forEach { sm ->
+          Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Checkbox(
+                checked = sm.enabled,
+                onCheckedChange = { viewModel.updateSocialMedia(sm.platform, it) },
+                modifier = Modifier.padding(0.dp))
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Icon(
+                painter =
+                    painterResource(SocialIcons.getIcon(sm.platform) ?: R.drawable.ic_default),
+                contentDescription = sm.platform,
+                tint = Color.Unspecified,
+                modifier = Modifier.size(32.dp))
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            OutlinedTextField(
+                value = sm.link,
+                onValueChange = { viewModel.updateSocialMediaLink(sm.platform, it) },
+                label = { Text("Link") },
+                enabled = sm.enabled,
+                modifier = Modifier.weight(1f))
+          }
+        }
+
+        // --- Upload Images (URLs) ---
+        Text("Upload Images", color = Color.Gray, style = MaterialTheme.typography.titleSmall)
+        HorizontalDivider(color = Color.Gray)
+
+        OutlinedTextField(
+            value = formState.logoUrl,
+            onValueChange = { viewModel.updateLogoUrl(it) },
+            label = { Text("Logo URL") },
+            modifier = Modifier.fillMaxWidth())
+
+        OutlinedTextField(
+            value = formState.bannerUrl,
+            onValueChange = { viewModel.updateBannerUrl(it) },
+            label = { Text("Banner URL") },
+            modifier = Modifier.fillMaxWidth())
+
+        Spacer(Modifier.height(24.dp))
+
+        // --- Submit Button ---
+        Button(
+            onClick = { viewModel.submit(onSubmitSuccess) },
+            enabled = viewModel.isFormValid(),
+            colors =
+                ButtonDefaults.buttonColors(containerColor = LifeRed, contentColor = Color.White),
+            modifier = Modifier.fillMaxWidth().height(50.dp)) {
+              Text("Submit", style = MaterialTheme.typography.bodyLarge)
+            }
+
+        Spacer(Modifier.height(24.dp))
+      }
+}

--- a/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationViewModel.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationViewModel.kt
@@ -1,11 +1,13 @@
 package ch.epfllife.ui.admin
 
+import android.util.Patterns
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import ch.epfllife.model.association.Association
 import ch.epfllife.ui.association.SocialIcons
+import java.net.URI
 
 data class SocialMediaEntry(
     val platform: String,
@@ -49,6 +51,25 @@ class AddEditAssociationViewModel(existingAssociation: Association? = null) : Vi
     }
   }
 
+  // URL Validation
+  private fun isValidUrl(url: String): Boolean {
+    if (url.isBlank()) return false
+
+    // Require http/https to avoid malformed schemes
+    if (!url.startsWith("http://") && !url.startsWith("https://")) return false
+
+    if (!Patterns.WEB_URL.matcher(url).matches()) return false
+
+    return try {
+      URI(url)
+      true
+    } catch (_: Exception) {
+      false
+    }
+  }
+
+  // main functions
+
   fun updateName(value: String) {
     formState = formState.copy(name = value)
   }
@@ -70,23 +91,32 @@ class AddEditAssociationViewModel(existingAssociation: Association? = null) : Vi
   }
 
   fun updateSocialMediaLink(platform: String, link: String) {
+    val sanitised = link.trim()
     val updatedList =
-        formState.socialMedia.map { if (it.platform == platform) it.copy(link = link) else it }
+        formState.socialMedia.map { if (it.platform == platform) it.copy(link = sanitised) else it }
     formState = formState.copy(socialMedia = updatedList)
   }
 
   fun updateLogoUrl(url: String) {
-    formState = formState.copy(logoUrl = url)
+    formState = formState.copy(logoUrl = url.trim())
   }
 
   fun updateBannerUrl(url: String) {
-    formState = formState.copy(bannerUrl = url)
+    formState = formState.copy(bannerUrl = url.trim())
   }
 
+  // form validation
   fun isFormValid(): Boolean {
-    return formState.name.isNotBlank() &&
-        formState.description.isNotBlank() &&
-        formState.about.isNotBlank()
+    val hasRequiredFields =
+        formState.name.isNotBlank() &&
+            formState.description.isNotBlank() &&
+            formState.about.isNotBlank()
+    val urlsAreValid =
+        (formState.logoUrl.isBlank() || isValidUrl(formState.logoUrl)) &&
+            (formState.bannerUrl.isBlank() || isValidUrl(formState.bannerUrl)) &&
+            formState.socialMedia.all { entry -> !entry.enabled || isValidUrl(entry.link) }
+
+    return hasRequiredFields && urlsAreValid
   }
 
   fun submit(onSuccess: () -> Unit) {

--- a/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationViewModel.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/AddEditAssociationViewModel.kt
@@ -1,0 +1,97 @@
+package ch.epfllife.ui.admin
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import ch.epfllife.model.association.Association
+import ch.epfllife.ui.association.SocialIcons
+
+data class SocialMediaEntry(
+    val platform: String,
+    var enabled: Boolean = false,
+    var link: String = ""
+)
+
+data class AssociationFormState(
+    var name: String = "",
+    var description: String = "", // short description
+    var about: String = "", // long description
+    var socialMedia: List<SocialMediaEntry> =
+        SocialIcons.platformOrder.map { SocialMediaEntry(it) },
+    var logoUrl: String = "",
+    var bannerUrl: String = ""
+)
+
+class AddEditAssociationViewModel(existingAssociation: Association? = null) : ViewModel() {
+
+  var formState by mutableStateOf(AssociationFormState())
+    private set
+
+  init {
+    existingAssociation?.let { assoc ->
+      val socialList =
+          SocialIcons.platformOrder.map { platform ->
+            SocialMediaEntry(
+                platform = platform,
+                enabled = assoc.socialLinks?.containsKey(platform) == true,
+                link = assoc.socialLinks?.get(platform) ?: "")
+          }
+
+      formState =
+          AssociationFormState(
+              name = assoc.name,
+              description = assoc.description,
+              about = assoc.about ?: "",
+              socialMedia = socialList,
+              logoUrl = assoc.logoUrl ?: "",
+              bannerUrl = assoc.pictureUrl ?: "")
+    }
+  }
+
+  fun updateName(value: String) {
+    formState = formState.copy(name = value)
+  }
+
+  fun updateDescription(value: String) {
+    formState = formState.copy(description = value)
+  }
+
+  fun updateAbout(value: String) {
+    formState = formState.copy(about = value)
+  }
+
+  fun updateSocialMedia(platform: String, enabled: Boolean) {
+    val updatedList =
+        formState.socialMedia.map {
+          if (it.platform == platform) it.copy(enabled = enabled) else it
+        }
+    formState = formState.copy(socialMedia = updatedList)
+  }
+
+  fun updateSocialMediaLink(platform: String, link: String) {
+    val updatedList =
+        formState.socialMedia.map { if (it.platform == platform) it.copy(link = link) else it }
+    formState = formState.copy(socialMedia = updatedList)
+  }
+
+  fun updateLogoUrl(url: String) {
+    formState = formState.copy(logoUrl = url)
+  }
+
+  fun updateBannerUrl(url: String) {
+    formState = formState.copy(bannerUrl = url)
+  }
+
+  fun isFormValid(): Boolean {
+    return formState.name.isNotBlank() &&
+        formState.description.isNotBlank() &&
+        formState.about.isNotBlank()
+  }
+
+  fun submit(onSuccess: () -> Unit) {
+    if (!isFormValid()) return
+    // TODO: send data to Firebase
+    onSuccess()
+  }
+}

--- a/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.epfllife.R
+import ch.epfllife.model.association.Association
 import ch.epfllife.model.db.Db
 import ch.epfllife.ui.composables.AssociationCard
 import ch.epfllife.ui.composables.BackButton
@@ -24,7 +25,7 @@ import ch.epfllife.ui.composables.SettingsButton
 fun SelectAssociationScreen(
     db: Db,
     onGoBack: () -> Unit,
-    onAssociationSelected: (String) -> Unit,
+    onAssociationSelected: (Association) -> Unit,
     onAddNewAssociation: () -> Unit = {},
     viewModel: SelectAssociationViewModel = viewModel { SelectAssociationViewModel(db) }
 ) {
@@ -57,6 +58,7 @@ fun SelectAssociationScreen(
         is SelectAssociationUIState.Success -> {
           val state = uiState as SelectAssociationUIState.Success
           val associations = state.associations
+          val selectedID = state.selectedAssociationId
 
           Column(
               modifier =
@@ -82,7 +84,7 @@ fun SelectAssociationScreen(
                       association = association,
                       onClick = {
                         viewModel.selectAssociation(association.id)
-                        onAssociationSelected(association.id)
+                        onAssociationSelected(association)
                       })
                 }
               }

--- a/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
@@ -1,0 +1,95 @@
+package ch.epfllife.ui.admin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.epfllife.R
+import ch.epfllife.model.db.Db
+import ch.epfllife.ui.composables.AssociationCard
+import ch.epfllife.ui.composables.BackButton
+import ch.epfllife.ui.composables.Refreshable
+import ch.epfllife.ui.composables.SettingsButton
+
+@Composable
+fun SelectAssociationScreen(
+    db: Db,
+    onGoBack: () -> Unit,
+    onAssociationSelected: (String) -> Unit,
+    onAddNewAssociation: () -> Unit = {},
+    viewModel: SelectAssociationViewModel = viewModel { SelectAssociationViewModel(db) }
+) {
+  val uiState by viewModel.uiState.collectAsState()
+
+  Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
+    Refreshable(onRefresh = { finishRefreshing -> viewModel.reload { finishRefreshing() } }) {
+      when (uiState) {
+        is SelectAssociationUIState.Loading -> {
+          Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+          }
+        }
+
+        is SelectAssociationUIState.Error -> {
+          val message = (uiState as SelectAssociationUIState.Error).message
+          Column(
+              modifier = Modifier.fillMaxSize().padding(horizontal = 32.dp),
+              verticalArrangement = Arrangement.Center,
+              horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = stringResource(R.string.error_loading_association, message),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.error)
+
+                Spacer(Modifier.height(16.dp))
+
+                Button(onClick = { viewModel.reload() }) { Text(stringResource(R.string.retry)) }
+              }
+        }
+
+        is SelectAssociationUIState.Success -> {
+          val associations = (uiState as SelectAssociationUIState.Success).associations
+
+          Column(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .verticalScroll(rememberScrollState())
+                      .padding(top = 80.dp, start = 16.dp, end = 16.dp, bottom = 60.dp),
+              verticalArrangement = Arrangement.spacedBy(20.dp)) {
+
+                // Add New Association button
+                SettingsButton(
+                    text = stringResource(R.string.add_new_association),
+                    onClick = onAddNewAssociation)
+
+                // Title
+                Text(
+                    text = stringResource(R.string.edit_existing_association),
+                    style = MaterialTheme.typography.titleMedium)
+
+                HorizontalDivider()
+
+                // List of associations
+                associations.forEach { association ->
+                  AssociationCard(
+                      association = association,
+                      onClick = { onAssociationSelected(association.id) })
+                }
+              }
+        }
+      }
+    }
+
+    // Back button
+    BackButton(
+        modifier = Modifier.align(Alignment.TopStart).padding(top = 16.dp, start = 16.dp),
+        onGoBack = onGoBack)
+  }
+}

--- a/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -20,6 +21,13 @@ import ch.epfllife.ui.composables.AssociationCard
 import ch.epfllife.ui.composables.BackButton
 import ch.epfllife.ui.composables.Refreshable
 import ch.epfllife.ui.composables.SettingsButton
+
+object SelectAssociationTestTags {
+  const val ASSOCIATION_LIST = "SelectAssociation_AssociationList"
+  const val ADD_NEW_BUTTON = "SelectAssociation_AddNewButton"
+
+  fun associationCard(id: String) = "SelectAssociation_Card_$id"
+}
 
 @Composable
 fun SelectAssociationScreen(
@@ -64,7 +72,8 @@ fun SelectAssociationScreen(
               modifier =
                   Modifier.fillMaxWidth()
                       .verticalScroll(rememberScrollState())
-                      .padding(top = 72.dp, start = 16.dp, end = 16.dp, bottom = 16.dp),
+                      .padding(top = 72.dp, start = 16.dp, end = 16.dp, bottom = 16.dp)
+                      .testTag(SelectAssociationTestTags.ASSOCIATION_LIST),
               verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 // --- Header Title ---
                 Text(
@@ -76,12 +85,14 @@ fun SelectAssociationScreen(
                 // Add New Association button
                 SettingsButton(
                     text = stringResource(R.string.add_new_association),
-                    onClick = onAddNewAssociation)
+                    onClick = onAddNewAssociation,
+                    modifier = Modifier.testTag(SelectAssociationTestTags.ADD_NEW_BUTTON))
 
                 // List of associations
                 associations.forEach { association ->
                   AssociationCard(
                       association = association,
+                      testTag = SelectAssociationTestTags.associationCard(association.id),
                       onClick = {
                         viewModel.selectAssociation(association.id)
                         onAssociationSelected(association)

--- a/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
@@ -8,7 +8,9 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.epfllife.R
@@ -47,9 +49,7 @@ fun SelectAssociationScreen(
                     text = stringResource(R.string.error_loading_association, message),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.error)
-
                 Spacer(Modifier.height(16.dp))
-
                 Button(onClick = { viewModel.reload() }) { Text(stringResource(R.string.retry)) }
               }
         }
@@ -57,26 +57,24 @@ fun SelectAssociationScreen(
         is SelectAssociationUIState.Success -> {
           val state = uiState as SelectAssociationUIState.Success
           val associations = state.associations
-          val selectedId = state.selectedAssociationId
 
           Column(
               modifier =
                   Modifier.fillMaxWidth()
                       .verticalScroll(rememberScrollState())
-                      .padding(top = 80.dp, start = 16.dp, end = 16.dp, bottom = 60.dp),
-              verticalArrangement = Arrangement.spacedBy(20.dp)) {
+                      .padding(top = 72.dp, start = 16.dp, end = 16.dp, bottom = 16.dp),
+              verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                // --- Header Title ---
+                Text(
+                    text = stringResource(R.string.settings_screen_association),
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold))
+                HorizontalDivider(color = Color.Black)
+                Spacer(Modifier.height(4.dp))
 
                 // Add New Association button
                 SettingsButton(
                     text = stringResource(R.string.add_new_association),
                     onClick = onAddNewAssociation)
-
-                // Title
-                Text(
-                    text = stringResource(R.string.edit_existing_association),
-                    style = MaterialTheme.typography.titleMedium)
-
-                HorizontalDivider()
 
                 // List of associations
                 associations.forEach { association ->
@@ -92,9 +90,7 @@ fun SelectAssociationScreen(
       }
     }
 
-    // Back button
-    BackButton(
-        modifier = Modifier.align(Alignment.TopStart).padding(top = 16.dp, start = 16.dp),
-        onGoBack = onGoBack)
+    // --- Back Button Overlay ---
+    BackButton(modifier = Modifier.align(Alignment.TopStart), onGoBack = onGoBack)
   }
 }

--- a/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
@@ -48,7 +48,6 @@ fun SelectAssociationScreen(
         }
 
         is SelectAssociationUIState.Error -> {
-          val message = (uiState as SelectAssociationUIState.Error).message
           Column(
               modifier = Modifier.fillMaxSize().padding(horizontal = 32.dp),
               verticalArrangement = Arrangement.Center,
@@ -65,7 +64,6 @@ fun SelectAssociationScreen(
         is SelectAssociationUIState.Success -> {
           val state = uiState as SelectAssociationUIState.Success
           val associations = state.associations
-          val selectedID = state.selectedAssociationId
 
           Column(
               modifier =

--- a/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
@@ -55,7 +55,9 @@ fun SelectAssociationScreen(
         }
 
         is SelectAssociationUIState.Success -> {
-          val associations = (uiState as SelectAssociationUIState.Success).associations
+          val state = uiState as SelectAssociationUIState.Success
+          val associations = state.associations
+          val selectedId = state.selectedAssociationId
 
           Column(
               modifier =
@@ -80,7 +82,10 @@ fun SelectAssociationScreen(
                 associations.forEach { association ->
                   AssociationCard(
                       association = association,
-                      onClick = { onAssociationSelected(association.id) })
+                      onClick = {
+                        viewModel.selectAssociation(association.id)
+                        onAssociationSelected(association.id)
+                      })
                 }
               }
         }

--- a/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -55,7 +54,7 @@ fun SelectAssociationScreen(
               verticalArrangement = Arrangement.Center,
               horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
-                    text = stringResource(R.string.error_loading_association, message),
+                    text = stringResource(R.string.error_loading_association),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.error)
                 Spacer(Modifier.height(16.dp))
@@ -79,7 +78,7 @@ fun SelectAssociationScreen(
                 Text(
                     text = stringResource(R.string.settings_screen_association),
                     style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold))
-                HorizontalDivider(color = Color.Black)
+                HorizontalDivider(color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Spacer(Modifier.height(4.dp))
 
                 // Add New Association button

--- a/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreenViewModel.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreenViewModel.kt
@@ -1,0 +1,46 @@
+package ch.epfllife.ui.admin
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import ch.epfllife.model.association.Association
+import ch.epfllife.model.db.Db
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+sealed interface SelectAssociationUIState {
+  object Loading : SelectAssociationUIState
+
+  data class Success(val associations: List<Association>) : SelectAssociationUIState
+
+  data class Error(val message: String) : SelectAssociationUIState
+}
+
+class SelectAssociationViewModel(private val db: Db) : ViewModel() {
+
+  private val _uiState =
+      MutableStateFlow<SelectAssociationUIState>(SelectAssociationUIState.Loading)
+  val uiState: StateFlow<SelectAssociationUIState> = _uiState
+
+  init {
+    loadAssociations()
+  }
+
+  private fun loadAssociations() {
+    viewModelScope.launch {
+      try {
+        val list = db.assocRepo.getAllAssociations()
+        _uiState.value = SelectAssociationUIState.Success(list)
+      } catch (e: Exception) {
+        _uiState.value = SelectAssociationUIState.Error(e.message ?: "Unknown error")
+      }
+    }
+  }
+
+  fun reload(onComplete: (() -> Unit)? = null) {
+    viewModelScope.launch {
+      loadAssociations()
+      onComplete?.invoke()
+    }
+  }
+}

--- a/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreenViewModel.kt
+++ b/app/src/main/java/ch/epfllife/ui/admin/SelectAssociationScreenViewModel.kt
@@ -11,9 +11,12 @@ import kotlinx.coroutines.launch
 sealed interface SelectAssociationUIState {
   object Loading : SelectAssociationUIState
 
-  data class Success(val associations: List<Association>) : SelectAssociationUIState
-
   data class Error(val message: String) : SelectAssociationUIState
+
+  data class Success(
+      val associations: List<Association>,
+      val selectedAssociationId: String? = null
+  ) : SelectAssociationUIState
 }
 
 class SelectAssociationViewModel(private val db: Db) : ViewModel() {
@@ -34,6 +37,13 @@ class SelectAssociationViewModel(private val db: Db) : ViewModel() {
       } catch (e: Exception) {
         _uiState.value = SelectAssociationUIState.Error(e.message ?: "Unknown error")
       }
+    }
+  }
+
+  fun selectAssociation(id: String) {
+    val current = _uiState.value
+    if (current is SelectAssociationUIState.Success) {
+      _uiState.value = current.copy(selectedAssociationId = id)
     }
   }
 

--- a/app/src/main/java/ch/epfllife/ui/composables/AssociationCard.kt
+++ b/app/src/main/java/ch/epfllife/ui/composables/AssociationCard.kt
@@ -23,13 +23,21 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 
 @Composable
-fun AssociationCard(association: Association, modifier: Modifier = Modifier, onClick: () -> Unit) {
+fun AssociationCard(
+    association: Association,
+    modifier: Modifier = Modifier,
+    testTag: String? = null,
+    onClick: () -> Unit
+) {
+  val baseModifier = modifier.fillMaxWidth().padding(5.dp)
+  val taggedModifier =
+      if (testTag != null) baseModifier.testTag(testTag)
+      else baseModifier.testTag(AssociationCardTestTags.ASSOCIATION_CARD)
   Card(
       onClick = onClick,
       shape = RoundedCornerShape(12.dp),
       elevation = CardDefaults.elevatedCardElevation(5.dp),
-      modifier =
-          modifier.fillMaxWidth().padding(5.dp).testTag(AssociationCardTestTags.ASSOCIATION_CARD)) {
+      modifier = taggedModifier) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/ch/epfllife/ui/composables/SettingsButton.kt
+++ b/app/src/main/java/ch/epfllife/ui/composables/SettingsButton.kt
@@ -1,0 +1,37 @@
+package ch.epfllife.ui.composables
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SettingsButton(modifier: Modifier = Modifier, text: String, onClick: () -> Unit) {
+  Button(
+      onClick = onClick,
+      modifier = modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(6.dp),
+      colors =
+          ButtonDefaults.buttonColors(
+              containerColor = MaterialTheme.colorScheme.surfaceVariant,
+              contentColor = MaterialTheme.colorScheme.onSurface),
+      contentPadding = PaddingValues(0.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically) {
+              Text(text = text, style = MaterialTheme.typography.bodyLarge)
+
+              Spacer(modifier = Modifier.weight(1f))
+
+              Icon(
+                  imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                  contentDescription = null,
+                  tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+      }
+}

--- a/app/src/main/java/ch/epfllife/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/epfllife/ui/navigation/NavigationActions.kt
@@ -27,6 +27,18 @@ sealed class Screen(
   object Map : Screen(route = "map", name = "Map")
 
   object SelectAssociation : Screen("selectassociation", name = "SelectAssociation")
+
+  object AddEditAssociation :
+      Screen(
+          route = "add_edit_association?associationId={associationId}",
+          name = "AddEditAssociation") {
+    private const val BASE_ROUTE = "add_edit_association"
+    const val ASSOCIATION_ID_ARG = "associationId"
+
+    fun createRoute(associationId: String? = null): String =
+        if (associationId.isNullOrBlank()) BASE_ROUTE
+        else "$BASE_ROUTE?$ASSOCIATION_ID_ARG=$associationId"
+  }
 }
 
 open class NavigationActions(
@@ -66,9 +78,21 @@ open class NavigationActions(
     navController.navigate(route)
   }
 
+  fun navigateToAssociationDetails(associationId: String) {
+    navigateToScreenWithId(Screen.AssociationDetails, associationId)
+  }
+
+  fun navigateToAddEditAssociation(associationId: String? = null) {
+    navController.navigate(Screen.AddEditAssociation.createRoute(associationId))
+  }
+
   /** Navigate back to the previous screen. */
   open fun goBack() {
     navController.popBackStack()
+  }
+
+  open fun currentRoute(): String {
+    return navController.currentDestination?.route ?: ""
   }
 
   /**
@@ -76,12 +100,4 @@ open class NavigationActions(
    *
    * @return The current route
    */
-  open fun currentRoute(): String {
-    return navController.currentDestination?.route ?: ""
-  }
-
-  fun navigateToAssociationDetails(associationId: String) {
-    val route = "${Screen.AssociationDetails.route}/$associationId"
-    navController.navigate(route)
-  }
 }

--- a/app/src/main/java/ch/epfllife/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/ch/epfllife/ui/navigation/NavigationActions.kt
@@ -25,6 +25,8 @@ sealed class Screen(
   object EventDetails : Screen(route = "eventdetails", name = "EventDetails")
 
   object Map : Screen(route = "map", name = "Map")
+
+  object SelectAssociation : Screen("selectassociation", name = "SelectAssociation")
 }
 
 open class NavigationActions(

--- a/app/src/main/java/ch/epfllife/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/settings/SettingsScreen.kt
@@ -36,6 +36,9 @@ import ch.epfllife.utils.ToastHelper
 
 object SettingsScreenTestTags {
   const val SIGN_OUT_BUTTON = "signOutButton"
+  const val SELECT_ASSOCIATION_BUTTON = "selectAssociationButton"
+  const val MANAGE_ASSOCIATION_BUTTON = "manageAssociationButton"
+  const val MANAGE_EVENTS_BUTTON = "manageAssociationEventsButton"
 }
 
 @Composable
@@ -100,7 +103,8 @@ fun SettingsScreen(
                   stringResource(R.string.settings_selected_association, it)
                 } ?: stringResource(R.string.settings_screen_association),
             onClick = onSelectAssociationClick,
-            modifier = Modifier.fillMaxWidth())
+            modifier =
+                Modifier.fillMaxWidth().testTag(SettingsScreenTestTags.SELECT_ASSOCIATION_BUTTON))
 
         Spacer(Modifier.height(16.dp))
 
@@ -110,12 +114,14 @@ fun SettingsScreen(
           SettingsButton(
               text = stringResource(R.string.manage_association, associationName),
               onClick = { onManageAssociationClick(associationId) },
-              modifier = Modifier.fillMaxWidth())
+              modifier =
+                  Modifier.fillMaxWidth().testTag(SettingsScreenTestTags.MANAGE_ASSOCIATION_BUTTON))
           Spacer(Modifier.height(16.dp))
           SettingsButton(
               text = stringResource(R.string.manage_association_events, associationName),
               onClick = { onManageAssociationEventsClick(associationId) },
-              modifier = Modifier.fillMaxWidth())
+              modifier =
+                  Modifier.fillMaxWidth().testTag(SettingsScreenTestTags.MANAGE_EVENTS_BUTTON))
         }
       }
 }

--- a/app/src/main/java/ch/epfllife/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/settings/SettingsScreen.kt
@@ -45,7 +45,11 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = viewModel { SettingsViewModel(auth) },
     onSignedOut: () -> Unit,
     toastHelper: ToastHelper = SystemToastHelper(),
-    onSelectAssociationClick: () -> Unit
+    onSelectAssociationClick: () -> Unit,
+    onManageAssociationClick: (String) -> Unit,
+    onManageAssociationEventsClick: (String) -> Unit,
+    selectedAssociationName: String? = null,
+    onAddNewAssociationClick: () -> Unit // added
 ) {
   val context = LocalContext.current
   val uiState by viewModel.uiState.collectAsState()
@@ -88,9 +92,26 @@ fun SettingsScreen(
             }
         Spacer(Modifier.height(20.dp))
 
+        // Select Association
         SettingsButton(
-            text = stringResource(R.string.settings_screen_association),
+            text =
+                selectedAssociationName?.let { "Selected: $it" }
+                    ?: stringResource(R.string.settings_screen_association),
             onClick = onSelectAssociationClick,
             modifier = Modifier.fillMaxWidth())
+
+        Spacer(Modifier.height(16.dp))
+
+        selectedAssociationName?.let { name ->
+          SettingsButton(
+              text = stringResource(R.string.manage_association, name),
+              onClick = { onManageAssociationClick(name) },
+              modifier = Modifier.fillMaxWidth())
+
+          SettingsButton(
+              text = stringResource(R.string.manage_association_events, name),
+              onClick = { onManageAssociationEventsClick(name) },
+              modifier = Modifier.fillMaxWidth())
+        }
       }
 }

--- a/app/src/main/java/ch/epfllife/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/settings/SettingsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.epfllife.R
 import ch.epfllife.model.authentication.Auth
+import ch.epfllife.ui.composables.SettingsButton
 import ch.epfllife.ui.navigation.NavigationTestTags
 import ch.epfllife.ui.theme.LifeRed
 import ch.epfllife.utils.SystemToastHelper
@@ -43,7 +44,8 @@ fun SettingsScreen(
     auth: Auth,
     viewModel: SettingsViewModel = viewModel { SettingsViewModel(auth) },
     onSignedOut: () -> Unit,
-    toastHelper: ToastHelper = SystemToastHelper()
+    toastHelper: ToastHelper = SystemToastHelper(),
+    onSelectAssociationClick: () -> Unit
 ) {
   val context = LocalContext.current
   val uiState by viewModel.uiState.collectAsState()
@@ -84,5 +86,11 @@ fun SettingsScreen(
                         MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold))
               }
             }
+        Spacer(Modifier.height(20.dp))
+
+        SettingsButton(
+            text = stringResource(R.string.settings_screen_association),
+            onClick = onSelectAssociationClick,
+            modifier = Modifier.fillMaxWidth())
       }
 }

--- a/app/src/main/java/ch/epfllife/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/settings/SettingsScreen.kt
@@ -48,8 +48,9 @@ fun SettingsScreen(
     onSelectAssociationClick: () -> Unit,
     onManageAssociationClick: (String) -> Unit,
     onManageAssociationEventsClick: (String) -> Unit,
+    selectedAssociationId: String? = null,
     selectedAssociationName: String? = null,
-    onAddNewAssociationClick: () -> Unit // added
+    onAddNewAssociationClick: () -> Unit
 ) {
   val context = LocalContext.current
   val uiState by viewModel.uiState.collectAsState()
@@ -95,22 +96,25 @@ fun SettingsScreen(
         // Select Association
         SettingsButton(
             text =
-                selectedAssociationName?.let { "Selected: $it" }
-                    ?: stringResource(R.string.settings_screen_association),
+                selectedAssociationName?.let {
+                  stringResource(R.string.settings_selected_association, it)
+                } ?: stringResource(R.string.settings_screen_association),
             onClick = onSelectAssociationClick,
             modifier = Modifier.fillMaxWidth())
 
         Spacer(Modifier.height(16.dp))
 
-        selectedAssociationName?.let { name ->
+        if (!selectedAssociationName.isNullOrBlank() && !selectedAssociationId.isNullOrBlank()) {
+          val associationName = selectedAssociationName
+          val associationId = selectedAssociationId
           SettingsButton(
-              text = stringResource(R.string.manage_association, name),
-              onClick = { onManageAssociationClick(name) },
+              text = stringResource(R.string.manage_association, associationName),
+              onClick = { onManageAssociationClick(associationId) },
               modifier = Modifier.fillMaxWidth())
-
+          Spacer(Modifier.height(16.dp))
           SettingsButton(
-              text = stringResource(R.string.manage_association_events, name),
-              onClick = { onManageAssociationEventsClick(name) },
+              text = stringResource(R.string.manage_association_events, associationName),
+              onClick = { onManageAssociationEventsClick(associationId) },
               modifier = Modifier.fillMaxWidth())
         }
       }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,14 @@
     <string name="edit_existing_association">Edit Existing Association</string>
     <string name="manage_association">Manage %1$s</string>
     <string name="manage_association_events">Manage %1$s\'s events</string>
+    <string name="general_info">General Information</string>
+    <string name="association_name_required">Association Name*</string>
+    <string name="short_description_required">Short Description*</string>
+    <string name="about_association_required">About the Association*</string>
+    <string name="upload_images">Upload Images</string>
+    <string name="logo_url">Logo URL</string>
+    <string name="banner_url">Banner URL</string>
+    <string name="submit">Submit</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,8 @@
     <string name="logo_url">Logo URL</string>
     <string name="banner_url">Banner URL</string>
     <string name="submit">Submit</string>
+    <string name="settings_selected_association">Selected: %1$s</string>
+
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,5 +70,13 @@
     <string name="error_unenroll_failed">Failed to unenroll: Please try again.</string>
     <string name="error_event_not_found">Failed to unenroll: Please try again.</string>
     <string name="error_loading_event">Failed to load event</string>
+    <string name="error_loading_associations">Failed to load associations: %1$s</string>
+    <string name="retry">Retry</string>
+
+
+    <!-- Admin -->
+    <string name="settings_screen_association">Select Association</string>
+    <string name="add_new_association">Add New Association</string>
+    <string name="edit_existing_association">Edit Existing Association</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,5 +78,8 @@
     <string name="settings_screen_association">Select Association</string>
     <string name="add_new_association">Add New Association</string>
     <string name="edit_existing_association">Edit Existing Association</string>
+    <string name="manage_association">Manage %1$s</string>
+    <string name="manage_association_events">Manage %1$s\'s events</string>
+
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,7 +77,6 @@
     <!-- Admin -->
     <string name="settings_screen_association">Select Association</string>
     <string name="add_new_association">Add New Association</string>
-    <string name="edit_existing_association">Edit Existing Association</string>
     <string name="manage_association">Manage %1$s</string>
     <string name="manage_association_events">Manage %1$s\'s events</string>
     <string name="general_info">General Information</string>


### PR DESCRIPTION
## Overview
This PR implements two new screens: `SelectAssociationScreen` and `AddEditAssociationScreen` and added new functionality to the settings page. 

## Description

- A new button has been added to the SettingsScreen to allow the user to "Select Association".
- The SettingsScreen UI had been updated to conditionally show the “Manage Association Events” and “Manage Association” buttons only after an association has been selected.
- Made a button composable which is used across the SettingsScreen and the new screens. 
- Completed the navigation between the settingsScreen and all the new screens and ensured the user flows specified in the figma are working.
- Wrote tests for the new screens

## New Userflows
This PR adds two new userflows: Add a new association, Edit an existing association.
- The user begins by pressing "Select Association" in the settings page.
- From there the user can select an existing association, or create a new one
- If they choose to create a new association, they are directed to a form to fill in all the required information for a new association
- If they select an existing association, the user is sent back to the settings screen and two new buttons appear: "Manage Association" and "Manage Association Events". 
- Currently only "Manage Association" is implemented, but pressing this allows the user to edit the association they previously selected. 
- The settingsScreen will remember the association selected until the user changes it, or navigates to a different page (navigates off the settingsPage)

This PR does not implement adding events or editing events. This will be done in a different PR as this one is already very big

This PR addresses #238.

### Screenshots of new screens provided below:
<img width="322" height="690" alt="image" src="https://github.com/user-attachments/assets/65505dd3-e71b-4dde-ab8b-425eaf1b7ad5" />
<img width="320" height="687" alt="image" src="https://github.com/user-attachments/assets/8389de33-fd7b-477d-aae6-8d6bae1fb6f1" />
<img width="329" height="686" alt="image" src="https://github.com/user-attachments/assets/5d3015ed-b362-45d5-b294-39721fa28524" />
<img width="325" height="689" alt="image" src="https://github.com/user-attachments/assets/bc4d93fb-1a3b-4b43-8a14-baef83b27a1c" />
<img width="327" height="687" alt="image" src="https://github.com/user-attachments/assets/5f88d0b3-4d79-4092-93eb-915a31a21280" />
