### PR TITLE
quickfix: inject maps api key from secrets so we can use maps

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -148,6 +148,7 @@ jobs:
           ./gradlew assembleDebug lint --parallel --build-cache
         env:
           DEBUG_KEYSTORE_PATH: ./debug.keystore
+          MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
 
       - name: Run tests
         run: |
@@ -155,6 +156,7 @@ jobs:
           ./gradlew check --parallel --build-cache
         env:
           DEBUG_KEYSTORE_PATH: ./debug.keystore
+          MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
 
       # Start Firebase emulators for instrumentation tests
       - name: Start Firebase emulators
@@ -181,6 +183,7 @@ jobs:
           script: ./gradlew connectedCheck --parallel --build-cache
         env:
           DEBUG_KEYSTORE_PATH: ./debug.keystore
+          MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
 
       # This step generates the coverage report which will be used later in the semster for monitoring purposes
       - name: Generate coverage

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,8 @@ android {
     localProperties.load(FileInputStream(localPropertiesFile))
   }
 
-  val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: ""
+  val mapsApiKey: String =
+      localProperties.getProperty("MAPS_API_KEY") ?: System.getenv("MAPS_API_KEY") ?: ""
 
   defaultConfig {
     applicationId = "ch.epfllife"


### PR DESCRIPTION
This quickfix injects the newly uploaded MPAS_API_KEY into the app from GitHub Secrets. This fixes all issues where the map was not showing properly.

- modified CI pipelpline to retrieve key
- if no local MAPS_API_KEY is set (when building locally) we automatically use the on from env

Tested locally and in CI myself, API key is provided by @pukoa420.