### PR TITLE
Fix date/time box in eventDetailsScreen

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
@@ -3,7 +3,6 @@ package ch.epfllife.ui.eventDetails
 // import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -82,8 +81,8 @@ class EventDetailsScreenTest {
   fun dateAndTime_areDisplayed() {
     composeTestRule.onNodeWithContentDescription("Date").assertExists()
     composeTestRule.onNodeWithContentDescription("Time").assertExists()
-    // FIX: Instead of assuming a single node, we assert that *at least one* node displays the text
-    composeTestRule.onAllNodesWithText("2025-10-12 18:00")[0].assertIsDisplayed()
+    composeTestRule.onNodeWithText("2025-10-12").assertIsDisplayed()
+    composeTestRule.onNodeWithText("18:00").assertIsDisplayed()
   }
 
   /** Checks that the “View Location on Map” section is present and clickable. */

--- a/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
@@ -8,12 +8,9 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import ch.epfllife.model.association.Association
+import ch.epfllife.example_data.ExampleEvents
 import ch.epfllife.model.db.Db
 import ch.epfllife.model.event.Event
-import ch.epfllife.model.event.EventCategory
-import ch.epfllife.model.map.Location
-import ch.epfllife.model.user.Price
 import ch.epfllife.ui.theme.Theme
 import org.junit.Before
 import org.junit.Rule
@@ -32,25 +29,7 @@ class EventDetailsScreenTest {
 
   @Before
   fun setUp() {
-    // Create a mock event similar to the one used in the Preview
-    sampleEvent =
-        Event(
-            id = "1",
-            title = "Drone Workshop",
-            description =
-                "The Drone Workshop is a multi-evening workshop organized by AéroPoly, where you can build your own 3-inch FPV drone...",
-            location = Location(46.5191, 6.5668, "Centre Sport et Santé"),
-            time = "2025-10-12 18:00",
-            association =
-                Association(
-                    id = "AeroPoly",
-                    name = "AeroPoly",
-                    description = "Description",
-                    eventCategory = EventCategory.ACADEMIC),
-            tags = listOf("workshop"),
-            price = Price(10u),
-            pictureUrl =
-                "https://www.shutterstock.com/image-photo/engineer-working-on-racing-fpv-600nw-2278353271.jpg")
+    sampleEvent = ExampleEvents.sampleEvent
   }
 
   private fun setSuccessContent(event: Event = sampleEvent) {
@@ -72,9 +51,9 @@ class EventDetailsScreenTest {
   @Test
   fun eventInformation_isDisplayedCorrectly() {
     setSuccessContent()
-    composeTestRule.onNodeWithText("Drone Workshop").assertIsDisplayed()
-    composeTestRule.onNodeWithText("AeroPoly").assertIsDisplayed()
-    composeTestRule.onNodeWithText("CHF 0.10").assertIsDisplayed()
+    composeTestRule.onNodeWithText(sampleEvent.title).assertIsDisplayed()
+    composeTestRule.onNodeWithText(sampleEvent.association.name).assertIsDisplayed()
+    composeTestRule.onNodeWithText(sampleEvent.price.toString()).assertIsDisplayed()
     composeTestRule.onNodeWithText("Description").assertIsDisplayed()
     composeTestRule.onNodeWithText(sampleEvent.description).assertIsDisplayed()
   }
@@ -88,15 +67,18 @@ class EventDetailsScreenTest {
     setSuccessContent()
     composeTestRule.onNodeWithContentDescription("Date").assertExists()
     composeTestRule.onNodeWithContentDescription("Time").assertExists()
-    composeTestRule.onNodeWithText("2025-10-12").assertIsDisplayed()
-    composeTestRule.onNodeWithText("18:00").assertIsDisplayed()
+    val (expectedDate, expectedTime) = sampleEvent.time.split(" ")
+    composeTestRule.onNodeWithText(expectedDate).assertIsDisplayed()
+    composeTestRule.onNodeWithText(expectedTime).assertIsDisplayed()
   }
 
   @Test
   fun timeWithDash_isFormattedWithColon() {
-    val dashedEvent = sampleEvent.copy(time = "2025-10-12 07-30")
+    val dashedTime = ExampleEvents.event1.time.replace(":", "-")
+    val dashedEvent = ExampleEvents.event1.copy(time = dashedTime)
     setSuccessContent(dashedEvent)
-    composeTestRule.onNodeWithText("07:30").assertIsDisplayed()
+    val expectedTime = ExampleEvents.event1.time.split(" ")[1]
+    composeTestRule.onNodeWithText(expectedTime).assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
@@ -53,10 +53,10 @@ class EventDetailsScreenTest {
                 "https://www.shutterstock.com/image-photo/engineer-working-on-racing-fpv-600nw-2278353271.jpg")
   }
 
-  private fun setSuccessContent() {
+  private fun setSuccessContent(event: Event = sampleEvent) {
     composeTestRule.setContent {
       Theme {
-        EventDetailsContent(event = sampleEvent, onGoBack = {}, onOpenMap = {}, onEnrollClick = {})
+        EventDetailsContent(event = event, onGoBack = {}, onOpenMap = {}, onEnrollClick = {})
       }
     }
   }
@@ -90,6 +90,13 @@ class EventDetailsScreenTest {
     composeTestRule.onNodeWithContentDescription("Time").assertExists()
     composeTestRule.onNodeWithText("2025-10-12").assertIsDisplayed()
     composeTestRule.onNodeWithText("18:00").assertIsDisplayed()
+  }
+
+  @Test
+  fun timeWithDash_isFormattedWithColon() {
+    val dashedEvent = sampleEvent.copy(time = "2025-10-12 07-30")
+    setSuccessContent(dashedEvent)
+    composeTestRule.onNodeWithText("07:30").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
@@ -2,12 +2,14 @@ package ch.epfllife.ui.eventDetails
 
 // import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import ch.epfllife.model.association.Association
+import ch.epfllife.model.db.Db
 import ch.epfllife.model.event.Event
 import ch.epfllife.model.event.EventCategory
 import ch.epfllife.model.map.Location
@@ -49,7 +51,9 @@ class EventDetailsScreenTest {
             price = Price(10u),
             pictureUrl =
                 "https://www.shutterstock.com/image-photo/engineer-working-on-racing-fpv-600nw-2278353271.jpg")
+  }
 
+  private fun setSuccessContent() {
     composeTestRule.setContent {
       Theme {
         EventDetailsContent(event = sampleEvent, onGoBack = {}, onOpenMap = {}, onEnrollClick = {})
@@ -60,12 +64,14 @@ class EventDetailsScreenTest {
   /** Ensures that the event image is visible. */
   @Test
   fun eventImage_isDisplayed() {
+    setSuccessContent()
     composeTestRule.onNodeWithContentDescription("Event Image").assertIsDisplayed()
   }
 
   /** Verifies that the title, club name, price, and description appear correctly. */
   @Test
   fun eventInformation_isDisplayedCorrectly() {
+    setSuccessContent()
     composeTestRule.onNodeWithText("Drone Workshop").assertIsDisplayed()
     composeTestRule.onNodeWithText("AeroPoly").assertIsDisplayed()
     composeTestRule.onNodeWithText("CHF 0.10").assertIsDisplayed()
@@ -79,15 +85,41 @@ class EventDetailsScreenTest {
    */
   @Test
   fun dateAndTime_areDisplayed() {
+    setSuccessContent()
     composeTestRule.onNodeWithContentDescription("Date").assertExists()
     composeTestRule.onNodeWithContentDescription("Time").assertExists()
     composeTestRule.onNodeWithText("2025-10-12").assertIsDisplayed()
     composeTestRule.onNodeWithText("18:00").assertIsDisplayed()
   }
 
+  @Test
+  fun errorState_displaysErrorMessage() {
+    val localDb = Db.freshLocal()
+    composeTestRule.setContent {
+      Theme {
+        EventDetailsScreen(
+            eventId = "missing",
+            db = localDb,
+            onOpenMap = {},
+            onGoBack = {},
+        )
+      }
+    }
+
+    composeTestRule.waitUntil(timeoutMillis = 5_000) {
+      composeTestRule
+          .onAllNodes(hasTestTag(EventDetailsTestTags.ERROR_MESSAGE))
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
+
+    composeTestRule.onNodeWithTag(EventDetailsTestTags.ERROR_MESSAGE).assertIsDisplayed()
+  }
+
   /** Checks that the “View Location on Map” section is present and clickable. */
   @Test
   fun viewLocationOnMap_isDisplayedAndClickable() {
+    setSuccessContent()
     composeTestRule
         .onNodeWithTag(EventDetailsTestTags.VIEW_LOCATION_BUTTON)
         .assertIsDisplayed()
@@ -97,6 +129,7 @@ class EventDetailsScreenTest {
   /** Ensures that the enrolment button is visible and can be clicked. */
   @Test
   fun enrollButton_isDisplayedAndClickable() {
+    setSuccessContent()
     composeTestRule.onNodeWithText("Enrol in event").assertIsDisplayed()
     composeTestRule.onNodeWithText("Enrol in event").performClick()
   }
@@ -104,6 +137,7 @@ class EventDetailsScreenTest {
   /** Checks that the back arrow button exists and can be clicked. */
   @Test
   fun backButton_isDisplayedAndClickable() {
+    setSuccessContent()
     composeTestRule.onNodeWithContentDescription("Back").assertIsDisplayed()
     composeTestRule.onNodeWithContentDescription("Back").performClick()
   }

--- a/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
@@ -5,8 +5,6 @@ import android.content.pm.PackageManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -198,41 +196,39 @@ fun EventDetailsContent(
 
             // Row containing: Date, Time, Location
             // TODO-question: make this clickable to be displayed in Calender?
-            FlowRow(
+            Row(
                 modifier =
                     Modifier.fillMaxWidth()
                         .wrapContentHeight()
                         .clip(RoundedCornerShape(8.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant)
                         .padding(12.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-                maxItemsInEachRow = 2,
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-              Row(
-                  modifier = Modifier.weight(1f, fill = false),
-                  verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Default.CalendarToday,
-                        contentDescription = "Date",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Column {
-                      Text(
-                          text = formattedDate,
-                          style = MaterialTheme.typography.bodyMedium,
-                          modifier = Modifier.testTag(EventDetailsTestTags.EVENT_TIME),
-                      )
-                      Text(
-                          text = formattedLocation,
-                          style = MaterialTheme.typography.bodySmall,
-                          maxLines = 3,
-                          overflow = TextOverflow.Ellipsis,
-                          modifier = Modifier.testTag(EventDetailsTestTags.EVENT_LOCATION),
-                      )
-                    }
-                  }
+              Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.CalendarToday,
+                    contentDescription = "Date",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Column {
+                  Text(
+                      text = formattedDate,
+                      style = MaterialTheme.typography.bodyMedium,
+                      modifier = Modifier.testTag(EventDetailsTestTags.EVENT_TIME),
+                  )
+                  Text(
+                      text = formattedLocation,
+                      style = MaterialTheme.typography.bodySmall,
+                      maxLines = 3,
+                      overflow = TextOverflow.Ellipsis,
+                      modifier = Modifier.testTag(EventDetailsTestTags.EVENT_LOCATION),
+                  )
+                }
+              }
+              Spacer(modifier = Modifier.width(16.dp))
               Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
                     imageVector = Icons.Default.AccessTime,


### PR DESCRIPTION
## Overview
Fix event details screen layout bug where sometimes the container height filled the full screen and added parsing of event date and time. 

### Description changes
- Added `wrapContentHeight()` and reduced `fillMaxSize()` to prevent the container from taking the full screen height
- Added formatting to split the `event.time` into separate date and time fields

The images below show the container with the date and time separated.
<img width="387" height="818" alt="image" src="https://github.com/user-attachments/assets/83f10538-8e72-4468-be72-e183e860754c" />
<img width="387" height="818" alt="image" src="https://github.com/user-attachments/assets/3eaf3c69-1b14-4dfb-9a80-c2d9f1625baa" />


This directly addresses issue #276 by fixing the container bug