### PR TITLE
quick-fix: add EPFL logo on top of association/calender

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/ui/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/home/HomeScreenTest.kt
@@ -14,6 +14,7 @@ import ch.epfllife.model.event.Event
 import ch.epfllife.model.event.EventRepositoryLocal
 import ch.epfllife.model.user.UserRepositoryLocal
 import ch.epfllife.ui.composables.DisplayedEventsTestTags
+import ch.epfllife.ui.composables.EPFLLogoTestTags
 import ch.epfllife.ui.composables.EventCardTestTags
 import ch.epfllife.ui.navigation.NavigationTestTags
 import ch.epfllife.ui.theme.Theme
@@ -76,7 +77,7 @@ class HomeScreenTest {
     composeTestRule.onNodeWithTag(NavigationTestTags.HOMESCREEN_SCREEN).assertIsDisplayed()
 
     // Check if EPFL logo is displayed
-    composeTestRule.onNodeWithTag(HomeScreenTestTags.EPFLLOGO).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(EPFLLogoTestTags.LOGO).assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfllife/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/navigation/NavigationTest.kt
@@ -13,9 +13,9 @@ import ch.epfllife.example_data.ExampleEvents
 import ch.epfllife.model.authentication.Auth
 import ch.epfllife.model.authentication.SignInResult
 import ch.epfllife.model.db.Db
+import ch.epfllife.ui.composables.EPFLLogoTestTags
 import ch.epfllife.ui.eventDetails.EventDetailsTestTags
 import ch.epfllife.ui.eventDetails.MapScreenTestTags
-import ch.epfllife.ui.home.HomeScreenTestTags
 import ch.epfllife.utils.FakeCredentialManager
 import ch.epfllife.utils.navigateToEvent
 import ch.epfllife.utils.navigateToTab
@@ -100,9 +100,7 @@ class NavigationTest {
     composeTestRule
         .onNodeWithTag(NavigationTestTags.HOMESCREEN_SCREEN, useUnmergedTree = true)
         .assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag(HomeScreenTestTags.EPFLLOGO, useUnmergedTree = true)
-        .assertIsDisplayed()
+    composeTestRule.onNodeWithTag(EPFLLogoTestTags.LOGO, useUnmergedTree = true).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU, useUnmergedTree = true)
         .assertIsDisplayed()
@@ -177,9 +175,7 @@ class NavigationTest {
     setUpApp()
     composeTestRule.navigateToTab(Tab.Settings)
     composeTestRule.navigateToTab(Tab.HomeScreen)
-    composeTestRule
-        .onNodeWithTag(HomeScreenTestTags.EPFLLOGO, useUnmergedTree = true)
-        .assertIsDisplayed()
+    composeTestRule.onNodeWithTag(EPFLLogoTestTags.LOGO, useUnmergedTree = true).assertIsDisplayed()
   }
 
   @Test
@@ -226,9 +222,7 @@ class NavigationTest {
     setUpApp()
     composeTestRule.navigateToTab(Tab.Calendar)
     composeTestRule.navigateToTab(Tab.HomeScreen)
-    composeTestRule
-        .onNodeWithTag(HomeScreenTestTags.EPFLLOGO, useUnmergedTree = true)
-        .assertIsDisplayed()
+    composeTestRule.onNodeWithTag(EPFLLogoTestTags.LOGO, useUnmergedTree = true).assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/ch/epfllife/ui/association/AssociationBrowser.kt
+++ b/app/src/main/java/ch/epfllife/ui/association/AssociationBrowser.kt
@@ -1,15 +1,12 @@
 package ch.epfllife.ui.association
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -19,9 +16,9 @@ import ch.epfllife.model.db.Db
 import ch.epfllife.model.enums.SubscriptionFilter
 import ch.epfllife.ui.composables.AssociationCard
 import ch.epfllife.ui.composables.DisplayedSubscriptionFilter
+import ch.epfllife.ui.composables.EPFLLogo
 import ch.epfllife.ui.composables.ListView
 import ch.epfllife.ui.composables.SearchBar
-import ch.epfllife.ui.home.HomeScreenTestTags
 import ch.epfllife.ui.navigation.NavigationTestTags
 
 @Composable
@@ -50,14 +47,7 @@ fun AssociationBrowser(
       horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     // Empty space where the logo would normally be
-    Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-      Image(
-          painter = painterResource(id = R.drawable.epfl_life_logo),
-          contentDescription = "EPFL Life Logo",
-          modifier = modifier.height(40.dp).testTag(HomeScreenTestTags.EPFLLOGO),
-          contentScale = ContentScale.Fit,
-      )
-    }
+    EPFLLogo(modifier = modifier)
 
     Spacer(Modifier.height(12.dp))
 

--- a/app/src/main/java/ch/epfllife/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/calendar/CalendarScreen.kt
@@ -1,6 +1,5 @@
 package ch.epfllife.ui.calendar
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
@@ -8,9 +7,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -20,9 +17,9 @@ import ch.epfllife.model.enums.SubscriptionFilter
 import ch.epfllife.model.event.Event
 import ch.epfllife.ui.composables.CalendarCard
 import ch.epfllife.ui.composables.DisplayedSubscriptionFilter
+import ch.epfllife.ui.composables.EPFLLogo
 import ch.epfllife.ui.composables.ListView
 import ch.epfllife.ui.composables.SearchBar
-import ch.epfllife.ui.home.HomeScreenTestTags
 import ch.epfllife.ui.home.HomeViewModel
 import ch.epfllife.ui.navigation.NavigationTestTags
 import java.time.LocalDate
@@ -81,14 +78,7 @@ fun CalendarScreen(
               .testTag(NavigationTestTags.CALENDAR_SCREEN),
       horizontalAlignment = Alignment.CenterHorizontally,
   ) {
-    Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-      Image(
-          painter = painterResource(id = R.drawable.epfl_life_logo),
-          contentDescription = "EPFL Life Logo",
-          modifier = modifier.height(40.dp).testTag(HomeScreenTestTags.EPFLLOGO),
-          contentScale = ContentScale.Fit,
-      )
-    }
+    EPFLLogo(modifier = modifier)
 
     Spacer(Modifier.height(12.dp))
 

--- a/app/src/main/java/ch/epfllife/ui/composables/EPFLLogo.kt
+++ b/app/src/main/java/ch/epfllife/ui/composables/EPFLLogo.kt
@@ -1,0 +1,37 @@
+package ch.epfllife.ui.composables
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ch.epfllife.R
+
+object EPFLLogoTestTags {
+  const val LOGO = "EPFL_LOGO"
+}
+
+@Composable
+fun EPFLLogo(modifier: Modifier = Modifier) {
+  Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+    Image(
+        painter = painterResource(id = R.drawable.epfl_life_logo),
+        contentDescription = "EPFL Life Logo",
+        modifier = Modifier.height(40.dp).testTag(EPFLLogoTestTags.LOGO),
+        contentScale = ContentScale.Fit,
+    )
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EPFLLogoPreview() {
+  EPFLLogo()
+}

--- a/app/src/main/java/ch/epfllife/ui/home/HomeScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package ch.epfllife.ui.home
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
@@ -11,11 +10,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -24,6 +20,7 @@ import ch.epfllife.R
 import ch.epfllife.model.db.Db
 import ch.epfllife.model.enums.SubscriptionFilter
 import ch.epfllife.ui.composables.DisplayedSubscriptionFilter
+import ch.epfllife.ui.composables.EPFLLogo
 import ch.epfllife.ui.composables.EventCard
 import ch.epfllife.ui.composables.ListView
 import ch.epfllife.ui.composables.SearchBar
@@ -52,14 +49,7 @@ fun HomeScreen(
               .fillMaxSize()
               .padding(horizontal = 16.dp, vertical = 12.dp)
               .testTag(NavigationTestTags.HOMESCREEN_SCREEN)) {
-        Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-          Image(
-              painter = painterResource(id = R.drawable.epfl_life_logo),
-              contentDescription = "EPFL Life Logo",
-              modifier = modifier.height(40.dp).testTag(HomeScreenTestTags.EPFLLOGO),
-              contentScale = ContentScale.Fit,
-          )
-        }
+        EPFLLogo(modifier = modifier)
 
         Spacer(Modifier.height(12.dp))
         var query by remember { mutableStateOf("") }
@@ -106,7 +96,7 @@ fun HomeScreen(
 }
 
 object HomeScreenTestTags {
-  const val EPFLLOGO = "EPFL_LOGO"
+
   const val BOTTON_SUBSCRIBED = "BUTTON_SUBSCRIBED"
   const val BUTTON_ALL = "BUTTON_ALL"
 }


### PR DESCRIPTION
As discussed the space on top of associationBrowserScreen and CalenderScreen were weird so i added the EPFL logo as on MainScreen and fixed the padding so the logo is same in all screens.