### PR TITLE
fix: delete enroll button when user is not enrolled

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/ui/composables/EventCardTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/composables/EventCardTest.kt
@@ -75,14 +75,11 @@ class EventCardTest {
     setEventCardContent(eventWithBanner, isEnrolled = true)
 
     composeTestRule.onNodeWithText("Enrolled", ignoreCase = false).assertIsDisplayed()
-    composeTestRule.onNodeWithText("Enroll", ignoreCase = false).assertDoesNotExist()
   }
 
   @Test
   fun enrollmentButton_isDisplayed_whenNotEnrolled() {
     setEventCardContent(eventWithBanner, isEnrolled = false)
-
-    composeTestRule.onNodeWithText("Enroll", ignoreCase = false).assertIsDisplayed()
     composeTestRule.onNodeWithText("Enrolled", ignoreCase = false).assertDoesNotExist()
   }
 }

--- a/app/src/androidTest/java/ch/epfllife/ui/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/home/HomeScreenTest.kt
@@ -449,13 +449,4 @@ class HomeScreenTest {
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithText("Enrolled", ignoreCase = false).assertExists()
   }
-
-  @Test
-  fun homeScreen_eventNotEnrolled_showsEnrollButton() {
-    setUpHomeScreen(allEvents = listOf(ExampleEvents.event1))
-
-    composeTestRule.onNodeWithTag(DisplayedEventsTestTags.BUTTON_ALL).performClick()
-    composeTestRule.waitForIdle()
-    composeTestRule.onNodeWithText("Enroll", ignoreCase = false).assertExists()
-  }
 }

--- a/app/src/main/java/ch/epfllife/ui/composables/EventCard.kt
+++ b/app/src/main/java/ch/epfllife/ui/composables/EventCard.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.unit.dp
 import ch.epfllife.R
 import ch.epfllife.model.event.Event
 import ch.epfllife.ui.theme.Enrolled
-import ch.epfllife.ui.theme.LifeRed
 import coil.compose.AsyncImage
 
 object EventCardTestTags {
@@ -78,17 +77,8 @@ fun EventCard(
                               style = MaterialTheme.typography.labelSmall,
                               color = Color.White)
                         }
-                  } else {
-                    Box(
-                        modifier =
-                            Modifier.background(color = LifeRed, shape = RoundedCornerShape(12.dp))
-                                .padding(horizontal = 10.dp, vertical = 4.dp)) {
-                          Text(
-                              text = stringResource(R.string.home_enroll_events),
-                              style = MaterialTheme.typography.labelSmall,
-                              color = Color.White)
-                        }
                   }
+
                   Spacer(Modifier.weight(1f))
                   Text(
                       text = event.price.formatPrice(),


### PR DESCRIPTION
Small PR where the enroll buttom was been deleted in order to have a better UX, as discussed on Discord. Now we only have an indicator when the user is enrolled, otherwise, nothing will appear.

Resolves issue [#315](https://github.com/EPFL-Life/life/issues/315)

<img width="363" height="735" alt="image" src="https://github.com/user-attachments/assets/bbe76821-aaa2-4e17-be09-a9e901599dfd" />
