### PR TITLE
quickfix: decrease timeout on CI 

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -157,7 +157,7 @@ jobs:
           MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
 
       - name: Run instrumentation tests
-        timeout-minutes: 60
+        timeout-minutes: 25
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34


### PR DESCRIPTION
We need to fail faster so the CI doesnt just run infinitely