### PR TITLE
Add location parsing logic (again)

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/ui/composables/EventCardTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/composables/EventCardTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import ch.epfllife.example_data.ExampleEvents
 import ch.epfllife.model.event.Event
+import ch.epfllife.model.map.Location
 import ch.epfllife.ui.theme.Theme
 import ch.epfllife.utils.assertClickable
 import org.junit.Rule
@@ -68,6 +69,25 @@ class EventCardTest {
     composeTestRule.onNodeWithText(eventWithBanner.association.name).assertIsDisplayed()
     composeTestRule.onNodeWithText(eventWithBanner.location.name).assertIsDisplayed()
     composeTestRule.onNodeWithText(eventWithBanner.time).assertIsDisplayed()
+  }
+
+  @Test
+  fun location_isShortenedToTextBeforeFirstComma_onCard() {
+    val longLocationName = "Here, Blackwall Tunnel, Blackwall Reach, Greater London, United Kingdom"
+    val eventWithLongLocation =
+        eventWithBanner.copy(
+            location =
+                Location(
+                    latitude = eventWithBanner.location.latitude,
+                    longitude = eventWithBanner.location.longitude,
+                    name = longLocationName,
+                ),
+        )
+
+    setEventCardContent(eventWithLongLocation, isEnrolled = false)
+
+    composeTestRule.onNodeWithText("Here").assertIsDisplayed()
+    composeTestRule.onNodeWithText(longLocationName).assertDoesNotExist()
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfllife/ui/endToEnd/AdminEndToEndTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/endToEnd/AdminEndToEndTest.kt
@@ -241,7 +241,7 @@ class AdminEndToEndTest {
     composeTestRule.onNodeWithText(newTitle).assertIsDisplayed()
   }
 
-  @Ignore("Currently broken")
+  @Ignore
   @Test
   fun createEventAsAssocAdmin() {
     val assoc = ExampleAssociations.association2

--- a/app/src/main/java/ch/epfllife/ui/composables/EventCard.kt
+++ b/app/src/main/java/ch/epfllife/ui/composables/EventCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -22,6 +23,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import ch.epfllife.R
 import ch.epfllife.model.event.Event
@@ -32,6 +34,13 @@ object EventCardTestTags {
   fun getEventCardTestTag(eventId: String) = "eventCard_$eventId"
 }
 
+private fun formatLocationForCard(locationName: String): String {
+  // Cards should stay compact: show only a short location label (before the first comma).
+  val normalized = locationName.lines().joinToString(" ") { it.trim() }.trim()
+  val short = normalized.substringBefore(",").trim()
+  return short.ifBlank { normalized }
+}
+
 @Composable
 fun EventCard(
     event: Event,
@@ -39,6 +48,7 @@ fun EventCard(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
+  val shortLocation = remember(event.location.name) { formatLocationForCard(event.location.name) }
 
   Card(
       onClick = onClick,
@@ -107,7 +117,7 @@ fun EventCard(
                 verticalAlignment = Alignment.CenterVertically) {
                   InfoItem(
                       icon = Icons.Outlined.CalendarMonth,
-                      text = event.location.name,
+                      text = shortLocation,
                       modifier = Modifier.weight(1f, fill = false))
                   Spacer(Modifier.width(16.dp))
                   InfoItem(icon = Icons.Outlined.AccessTime, text = event.time)
@@ -132,7 +142,9 @@ private fun InfoItem(
     Text(
         text = text,
         style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant)
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis)
   }
 }
 


### PR DESCRIPTION
In some cases the location name is extremely long, which make the EventCard excessively tall and it looks bad. This PR parses the event name so that it only takes values from before the first comma.

This addresses issue #335 as it parses event locations in the event card