### PR TITLE
Fix long event titles

### DIFF
--- a/app/src/main/java/ch/epfllife/ui/composables/EventCard.kt
+++ b/app/src/main/java/ch/epfllife/ui/composables/EventCard.kt
@@ -78,7 +78,7 @@ fun EventCard(
                       fontWeight = FontWeight.SemiBold,
                       maxLines = 2,
                       overflow = TextOverflow.Ellipsis,
-                      modifier = Modifier.weight(1f, fill = false))
+                      modifier = Modifier.weight(1f))
                   Spacer(Modifier.width(8.dp))
                   if (isEnrolled) {
                     Box(
@@ -167,7 +167,7 @@ fun CompactEventCard(
             modifier = Modifier.fillMaxWidth().padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween) {
-              Column(modifier = Modifier.weight(1f, fill = false)) {
+              Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = event.title,
                     style = MaterialTheme.typography.titleMedium,

--- a/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
@@ -207,8 +207,7 @@ private fun EventHeader(
           title,
           style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
           modifier = Modifier.testTag(EventDetailsTestTags.EVENT_TITLE),
-          maxLines = 2,
-          overflow = TextOverflow.Ellipsis,
+          maxLines = Int.MAX_VALUE,
       )
       Text(
           associationName,


### PR DESCRIPTION
Longer event titles would previously break the layout. This is now fixed both in the Card and the DetailsScreen
<img width="279" height="241" alt="image" src="https://github.com/user-attachments/assets/4b01a47c-962e-45b9-ad40-68873d505e86" />
<img width="273" height="151" alt="image" src="https://github.com/user-attachments/assets/a24f45fe-aeb4-4b80-b396-944148b2ecdb" />
