### PR TITLE
Unignore createEventAsAssocAdmin test

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/ui/endToEnd/AdminEndToEndTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/endToEnd/AdminEndToEndTest.kt
@@ -43,7 +43,6 @@ import ch.epfllife.utils.setUpEmulator
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -241,7 +240,6 @@ class AdminEndToEndTest {
     composeTestRule.onNodeWithText(newTitle).assertIsDisplayed()
   }
 
-  @Ignore
   @Test
   fun createEventAsAssocAdmin() {
     val assoc = ExampleAssociations.association2

--- a/app/src/androidTest/java/ch/epfllife/ui/endToEnd/AdminEndToEndTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/endToEnd/AdminEndToEndTest.kt
@@ -269,15 +269,19 @@ class AdminEndToEndTest {
     composeTestRule
         .onNodeWithTag(AddEditEventTestTags.DESCRIPTION_FIELD)
         .performTextInput("Event Description")
+    composeTestRule.waitForIdle()
     Espresso.closeSoftKeyboard()
     composeTestRule.onNodeWithTag(AddEditEventTestTags.TIME_PICKER_BOX).performClick()
     // Interact with DatePicker (Click OK to accept default/current date)
     onView(withText("OK")).perform(click())
     // Interact with TimePicker (Click OK to accept default/current time)
     onView(withText("OK")).perform(click())
+    composeTestRule.waitForIdle()
+    Thread.sleep(1000)
     composeTestRule.onNodeWithTag(AddEditEventTestTags.SUBMIT_BUTTON).performScrollTo()
     composeTestRule.onNodeWithTag(AddEditEventTestTags.SUBMIT_BUTTON).performClick()
     composeTestRule.waitForIdle()
+    Thread.sleep(1000)
 
     // Verify event created on manage events screen
     composeTestRule.waitUntil { composeTestRule.onNodeWithText(eventTitle).isDisplayed() }


### PR DESCRIPTION
### Overview

Run `createEventAsAssocAdmin` end-to-end test again. The original reason why it lead to crashes was fixed in #329.
It was still flaky on CI (not locally) though. This PR introduces a few `sleep` calls to make it more stable on the slower CI.