### PR TITLE
Implement share button

### DIFF
--- a/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/EventDetailsScreenTest.kt
@@ -1,19 +1,33 @@
 package ch.epfllife.ui.eventDetails
 
 // import androidx.compose.ui.test.assertExists
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import ch.epfllife.R
 import ch.epfllife.example_data.ExampleEvents
 import ch.epfllife.example_data.ExampleUsers
 import ch.epfllife.model.db.Db
 import ch.epfllife.model.event.Event
 import ch.epfllife.model.user.User
 import ch.epfllife.ui.theme.Theme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -48,7 +62,8 @@ class EventDetailsScreenTest {
             onGoBack = {},
             onOpenMap = {},
             onEnrollClick = {},
-            onAssociationClick = {})
+            onAssociationClick = {},
+            onShare = {})
       }
     }
   }
@@ -151,5 +166,76 @@ class EventDetailsScreenTest {
     setSuccessContent(attendees = attendees, onAttendeesClick = { clicked = true })
     composeTestRule.onNodeWithText("2 attending").performClick()
     org.junit.Assert.assertTrue("Attendee row should trigger callback", clicked)
+  }
+
+  @Test
+  fun shareMessage_includesResolvedImageUrl_andChooserWrapsSendIntent() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val event = ExampleEvents.event3 // has pictureUrl = null
+    val senderName = ExampleUsers.user1.name
+
+    val shareText =
+        buildShareMessage(
+            context = context,
+            eventTitle = event.title,
+            senderName = senderName,
+            pictureUrl = event.pictureUrl,
+        )
+
+    val expectedImageUrl = resolveShareImageUrl(event.pictureUrl)
+    assertTrue(shareText.contains(event.title))
+    assertTrue(shareText.contains(senderName))
+    assertTrue(shareText.contains(expectedImageUrl))
+
+    val chooser = buildShareChooserIntent(context, shareText)
+    assertEquals(Intent.ACTION_CHOOSER, chooser.action)
+    assertTrue((chooser.flags and Intent.FLAG_ACTIVITY_NEW_TASK) != 0)
+
+    val innerSendIntent: Intent? =
+        if (Build.VERSION.SDK_INT >= 33) {
+          chooser.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+        } else {
+          @Suppress("DEPRECATION") chooser.getParcelableExtra(Intent.EXTRA_INTENT) as? Intent
+        }
+    assertNotNull(innerSendIntent)
+    assertEquals(Intent.ACTION_SEND, innerSendIntent!!.action)
+    assertEquals("text/plain", innerSendIntent.type)
+    assertEquals(shareText, innerSendIntent.getStringExtra(Intent.EXTRA_TEXT))
+  }
+
+  @Test
+  fun description_showsShowMore_whenOverflow_andTogglesToShowLess_onClick() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val showMore = context.getString(R.string.show_more)
+    val showLess = context.getString(R.string.show_less)
+
+    val base = ExampleEvents.sampleEvent
+    val longDescription = (base.description + " ").repeat(80)
+    val event = base.copy(description = longDescription)
+
+    composeTestRule.setContent {
+      Theme {
+        // Constrain width to make overflow deterministic in tests.
+        Box(Modifier.width(220.dp)) {
+          EventDetailsContent(
+              event = event,
+              attendees = emptyList(),
+              onAttendeesClick = {},
+              onGoBack = {},
+              onOpenMap = {},
+              onAssociationClick = {},
+              onEnrollClick = {},
+          )
+        }
+      }
+    }
+
+    composeTestRule.waitUntil(timeoutMillis = 5_000) {
+      composeTestRule.onAllNodesWithText(showMore).fetchSemanticsNodes().isNotEmpty()
+    }
+
+    composeTestRule.onNodeWithText(showMore).performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithText(showMore).performClick()
+    composeTestRule.onNodeWithText(showLess).performScrollTo().assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/ch/epfllife/ui/composables/ShareButtonTest.kt
+++ b/app/src/androidTest/java/ch/epfllife/ui/composables/ShareButtonTest.kt
@@ -1,0 +1,45 @@
+package ch.epfllife.ui.composables
+
+import android.content.Context
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import ch.epfllife.R
+import ch.epfllife.ui.theme.Theme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class ShareButtonTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun shareButton_isDisplayed_withShareContentDescription_andIsClickable() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val shareContentDescription = context.getString(R.string.share)
+
+    composeTestRule.setContent { Theme { ShareButton(onShare = {}) } }
+
+    composeTestRule
+        .onNodeWithContentDescription(shareContentDescription)
+        .assertIsDisplayed()
+        .assertHasClickAction()
+  }
+
+  @Test
+  fun shareButton_triggersCallback_whenClicked() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val shareContentDescription = context.getString(R.string.share)
+    var clicks = 0
+
+    composeTestRule.setContent { Theme { ShareButton(onShare = { clicks += 1 }) } }
+
+    composeTestRule.onNodeWithContentDescription(shareContentDescription).performClick()
+
+    composeTestRule.runOnIdle { assertEquals(1, clicks) }
+  }
+}

--- a/app/src/main/java/ch/epfllife/ui/composables/ShareButton.kt
+++ b/app/src/main/java/ch/epfllife/ui/composables/ShareButton.kt
@@ -1,0 +1,32 @@
+package ch.epfllife.ui.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import ch.epfllife.R
+
+@Composable
+fun ShareButton(modifier: Modifier = Modifier, onShare: () -> Unit) {
+  IconButton(
+      onClick = onShare,
+      modifier =
+          modifier
+              .padding(16.dp)
+              .size(40.dp)
+              .background(Color.Black.copy(alpha = 0.4f), CircleShape)) {
+        Icon(
+            imageVector = Icons.Filled.Share,
+            contentDescription = stringResource(R.string.share),
+            tint = Color.White)
+      }
+}

--- a/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
+++ b/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsScreen.kt
@@ -1,6 +1,10 @@
 package ch.epfllife.ui.eventDetails
 
 import android.Manifest
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -34,6 +38,7 @@ import ch.epfllife.model.map.Location
 import ch.epfllife.model.user.User
 import ch.epfllife.ui.composables.BackButton
 import ch.epfllife.ui.composables.Map
+import ch.epfllife.ui.composables.ShareButton
 import ch.epfllife.ui.theme.LifeRed
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
@@ -52,6 +57,35 @@ object EventDetailsTestTags {
   const val VIEW_LOCATION_BUTTON = "viewLocationButton"
   const val ENROLL_BUTTON = "enrollButton"
   const val CONTENT = "eventDetailsContent"
+}
+
+private const val DEFAULT_EVENT_IMAGE_URL =
+    "https://www.epfl.ch/campus/services/events/wp-content/uploads/2024/09/WEB_Image-Home-Events_ORGANISER.png"
+
+internal fun resolveShareImageUrl(pictureUrl: String?): String =
+    pictureUrl?.trim().takeUnless { it.isNullOrEmpty() } ?: DEFAULT_EVENT_IMAGE_URL
+
+internal fun buildShareMessage(
+    context: Context,
+    eventTitle: String,
+    senderName: String,
+    pictureUrl: String?,
+): String {
+  val imageUrl = resolveShareImageUrl(pictureUrl)
+  val message = context.getString(R.string.share_invite_message, eventTitle, senderName)
+  return "$message\n\n$imageUrl"
+}
+
+internal fun buildShareChooserIntent(context: Context, shareText: String): Intent {
+  val sendIntent =
+      Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, shareText)
+      }
+
+  return Intent.createChooser(sendIntent, context.getString(R.string.share)).apply {
+    if (context !is Activity) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+  }
 }
 
 @Composable
@@ -87,6 +121,26 @@ fun EventDetailsScreen(
     }
 
     is EventDetailsUIState.Success -> {
+      val onShareEvent =
+          remember(state.event.title, state.senderName, state.event.pictureUrl, context) {
+            {
+              val messageWithImage =
+                  buildShareMessage(
+                      context = context,
+                      eventTitle = state.event.title,
+                      senderName = state.senderName,
+                      pictureUrl = state.event.pictureUrl,
+                  )
+              val chooser = buildShareChooserIntent(context, messageWithImage)
+
+              try {
+                context.startActivity(chooser)
+              } catch (_: ActivityNotFoundException) {
+                // No compatible activity to handle sharing on this device.
+              }
+            }
+          }
+
       EventDetailsContent(
           event = state.event,
           isEnrolled = state.isEnrolled,
@@ -97,7 +151,7 @@ fun EventDetailsScreen(
           onAssociationClick = onAssociationClick,
           onEnrollClick = { viewModel.enrollInEvent(state.event, context) },
           onUnenrollClick = { viewModel.unenrollFromEvent(state.event, context) },
-      )
+          onShare = onShareEvent)
     }
   }
 }
@@ -113,6 +167,7 @@ fun EventDetailsContent(
     onOpenMap: (Location) -> Unit,
     onAssociationClick: (String) -> Unit,
     onEnrollClick: () -> Unit,
+    onShare: () -> Unit = {},
     onUnenrollClick: () -> Unit = {},
 ) {
 
@@ -136,7 +191,9 @@ fun EventDetailsContent(
           .background(MaterialTheme.colorScheme.surface)
           .testTag(EventDetailsTestTags.CONTENT)) {
         Column(Modifier.fillMaxWidth().verticalScroll(rememberScrollState())) {
-          EventImage(event.pictureUrl)
+          EventImage(event.pictureUrl) {
+            ShareButton(modifier = Modifier.align(Alignment.TopEnd), onShare = onShare)
+          }
 
           Column(
               Modifier.fillMaxWidth().padding(16.dp),
@@ -173,9 +230,14 @@ fun EventDetailsContent(
 }
 
 @Composable
-private fun EventImage(pictureUrl: String?) {
+private fun EventImage(
+    pictureUrl: String?,
+    modifier: Modifier = Modifier,
+    overlayContent: @Composable BoxScope.() -> Unit
+) {
   val context = LocalContext.current
-  Box(Modifier.fillMaxWidth()) {
+
+  Box(modifier = modifier.fillMaxWidth().height(260.dp)) {
     AsyncImage(
         model =
             ImageRequest.Builder(context)
@@ -186,11 +248,12 @@ private fun EventImage(pictureUrl: String?) {
                 .build(),
         contentDescription = "Event Image",
         modifier =
-            Modifier.fillMaxWidth()
-                .height(260.dp)
+            Modifier.matchParentSize()
                 .clip(RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp))
                 .testTag(EventDetailsTestTags.EVENT_IMAGE),
         contentScale = ContentScale.Crop)
+
+    overlayContent()
   }
 }
 

--- a/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsViewModel.kt
+++ b/app/src/main/java/ch/epfllife/ui/eventDetails/EventDetailsViewModel.kt
@@ -16,8 +16,12 @@ import kotlinx.coroutines.launch
 sealed class EventDetailsUIState {
   object Loading : EventDetailsUIState()
 
-  data class Success(val event: Event, val isEnrolled: Boolean, val attendees: List<User>) :
-      EventDetailsUIState()
+  data class Success(
+      val event: Event,
+      val isEnrolled: Boolean,
+      val attendees: List<User>,
+      val senderName: String = "",
+  ) : EventDetailsUIState()
 
   data class Error(val message: String) : EventDetailsUIState()
 }
@@ -42,6 +46,9 @@ class EventDetailsViewModel(
         val event = db.eventRepo.getEvent(eventId)
         val user = db.userRepo.getCurrentUser()
         currentUser = user
+        val senderName =
+            user?.name?.takeIf { it.isNotBlank() }
+                ?: context.getString(R.string.share_sender_unknown)
 
         if (event == null) {
           _uiState.value =
@@ -54,7 +61,8 @@ class EventDetailsViewModel(
             EventDetailsUIState.Success(
                 event = event,
                 isEnrolled = user?.enrolledEvents?.contains(eventId) == true,
-                attendees = attendees)
+                attendees = attendees,
+                senderName = senderName)
       } catch (e: Exception) {
         _uiState.value = EventDetailsUIState.Error(context.getString(R.string.error_loading_event))
       }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -136,6 +136,9 @@
         <string name="search_bar_placeholder">Rechercher…</string>
         <string name="show_more">Afficher plus…</string>
         <string name="show_less">Afficher moins</string>
+        <string name="share">Partager</string>
+        <string name="share_sender_unknown">Quelqu\'une</string>
+        <string name="share_invite_message">Vous êtes invité à %1$s par %2$s ! Téléchargez l\'application EPFL Life pour en savoir plus.</string>
 
         <string name="calendar_previous_month">Mois précédent</string>
         <string name="calendar_next_month">Mois suivant</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,9 @@ Use your full name so friends can easily find you in event participant lists.
     <string name="search_bar_placeholder">Search…</string>
     <string name="show_more">Show more…</string>
     <string name="show_less">Show less</string>
+    <string name="share">Share</string>
+    <string name="share_sender_unknown">Someone</string>
+    <string name="share_invite_message">You have been invited to %1$s by %2$s! Download the EPFL Life app to check it out.</string>
 
     <string name="calendar_previous_month">Previous Month</string>
     <string name="calendar_next_month">Next Month</string>


### PR DESCRIPTION
--- THIS PR WAS DONE BY KIAN ---
( i messed up a rebase therefore i remerge this)

## Overview
This PR adds a share button to the event details screen which allows users to send a prewritten message to any social media app to invite their friends to the event. This encourages social interaction across the app and also fits with my previous implementation of the attendee list (So you can send events to your friends if you see they aren't enrolled)

## Description
- Added a new composable `ShareButton` which looks similar to the `BackButton` but with a share icon
- The `ShareButton` appears in the top right of the event banner on the EventDetailsScreen
- Pressing the button will open the system share tray where you can select any social media app
- The message is written in the format: "You have been invited to {EventName} by{AccountName} ! Download the EPFL Life app to check it out."